### PR TITLE
ZeroSSL和Google EAB支持自动获取及Google反向代理

### DIFF
--- a/app/lib/CertHelper.php
+++ b/app/lib/CertHelper.php
@@ -75,7 +75,7 @@ class CertHelper
             'wildcard' => true,
             'max_domains' => 100,
             'cname' => true,
-            'note' => '<a href="https://cloud.google.com/certificate-manager/docs/public-ca-tutorial" target="_blank" rel="noreferrer">查看Google SSL账户配置说明</a>',
+            'note' => 'EAB支持通过第三方接口<a href="https://panel.haozi.net" target="_blank" rel="noreferrer">（耗子面板提供）</a>自动获取（不支持测试环境）或手动输入，<a href="https://cloud.google.com/certificate-manager/docs/public-ca-tutorial" target="_blank" rel="noreferrer">查看Google SSL账户手动配置说明</a>',
             'inputs' => [
                 'email' => [
                     'name' => '邮箱地址',
@@ -83,17 +83,28 @@ class CertHelper
                     'placeholder' => 'EAB申请邮箱',
                     'required' => true,
                 ],
+                'eabMode' => [
+                    'name' => 'EAB获取方式',
+                    'type' => 'radio',
+                    'options' => [
+                        'auto' => '自动获取',
+                        'manual' => '手动输入',
+                    ],
+                    'value' => 'auto'
+                ],
                 'kid' => [
                     'name' => 'keyId',
                     'type' => 'input',
                     'placeholder' => '',
                     'required' => true,
+                    'show' => 'eabMode==\'manual\'',
                 ],
                 'key' => [
                     'name' => 'b64MacKey',
                     'type' => 'input',
                     'placeholder' => '',
                     'required' => true,
+                    'show' => 'eabMode==\'manual\'',
                 ],
                 'mode' => [
                     'name' => '环境选择',
@@ -110,8 +121,16 @@ class CertHelper
                     'options' => [
                         '0' => '否',
                         '1' => '是',
+                        '2' => '是（反向代理）'
                     ],
                     'value' => '0'
+                ],
+                'proxy_url' => [
+                    'name' => '反向代理地址',
+                    'type' => 'input',
+                    'placeholder' => 'https://dv.acme-v02.api.pki.goog',
+                    'required' => true,
+                    'show' => 'proxy==2',
                 ],
             ]
         ],
@@ -348,7 +367,8 @@ class CertHelper
         return false;
     }
 
-    public static function getPfx($fullchain, $privatekey, $pwd = '123456'){
+    public static function getPfx($fullchain, $privatekey, $pwd = '123456')
+    {
         openssl_pkcs12_export($fullchain, $pfx, $privatekey, $pwd);
         return $pfx;
     }

--- a/app/lib/CertHelper.php
+++ b/app/lib/CertHelper.php
@@ -49,24 +49,12 @@ class CertHelper
             'wildcard' => true,
             'max_domains' => 100,
             'cname' => true,
-            'note' => '<a href="https://app.zerossl.com/developer" target="_blank" rel="noreferrer">ZeroSSL密钥生成地址</a>',
+            'note' => null,
             'inputs' => [
                 'email' => [
                     'name' => '邮箱地址',
                     'type' => 'input',
                     'placeholder' => 'EAB申请邮箱',
-                    'required' => true,
-                ],
-                'kid' => [
-                    'name' => 'EAB KID',
-                    'type' => 'input',
-                    'placeholder' => '',
-                    'required' => true,
-                ],
-                'key' => [
-                    'name' => 'EAB HMAC Key',
-                    'type' => 'input',
-                    'placeholder' => '',
                     'required' => true,
                 ],
                 'proxy' => [

--- a/app/lib/CertHelper.php
+++ b/app/lib/CertHelper.php
@@ -128,9 +128,26 @@ class CertHelper
                 'proxy_url' => [
                     'name' => '反向代理地址',
                     'type' => 'input',
-                    'placeholder' => 'https://dv.acme-v02.api.pki.goog',
+                    'placeholder' => 'https://gts.rat.dev',
                     'required' => true,
                     'show' => 'proxy==2',
+	                'note' => '反向代理配置参考：
+					<pre>resolver 8.8.8.8 ipv6=off valid=300s;
+resolver_timeout 10s;
+
+location / {
+    set $empty "";
+    proxy_pass https://dv.acme-v02.api.pki.goog$empty;
+    proxy_set_header Accept-Encoding "";
+    proxy_ssl_session_reuse off;
+    proxy_ssl_server_name on;
+    proxy_ssl_protocols TLSv1.2 TLSv1.3;
+    proxy_http_version 1.1;
+
+    sub_filter_once off;
+    sub_filter_types *;
+    sub_filter \'dv.acme-v02.api.pki.goog\' \'gts.rat.dev\'; # 替换自己的域名
+}</pre>',
                 ],
             ]
         ],

--- a/app/lib/acme/ACMECert.php
+++ b/app/lib/acme/ACMECert.php
@@ -25,7 +25,7 @@ class ACMECert extends ACMEv2
 		$protected = array(
 			'alg' => 'HS256',
 			'kid' => $eab_kid,
-			'url' => $this->resources['newAccount']
+			'url' => $this->unproxiedURL($this->resources['newAccount'])
 		);
 		$payload = $this->jwk_header['jwk'];
 

--- a/app/lib/acme/ACMEv2.php
+++ b/app/lib/acme/ACMEv2.php
@@ -21,9 +21,9 @@ class ACMEv2
     {
 		$this->directory = $directory;
 		$this->proxy = $proxy;
-        if ($proxy == 2) {
-            $this->proxy_config = $proxy_config;
-        }
+		if ($proxy == 2) {
+			$this->proxy_config = $proxy_config;
+		}
 	}
 
 	public function __destruct()
@@ -199,8 +199,8 @@ class ACMEv2
 		}
 
 		if (!$this->kid_header['kid'] && $type === 'newAccount') {
-            // 反向替换反向代理配置，防止破坏签名
-            $this->kid_header['kid'] = $this->unproxiedURL($ret['headers']['location']);
+			// 反向替换反向代理配置，防止破坏签名
+			$this->kid_header['kid'] = $this->unproxiedURL($ret['headers']['location']);
 			$this->log('AccountID: ' . $this->kid_header['kid']);
 		}
 
@@ -229,7 +229,7 @@ class ACMEv2
 		}
 
 		// 反向替换反向代理配置，防止破坏签名
-        $protected['url'] = $this->unproxiedURL($this->resources[$type]);
+		$protected['url'] = $this->unproxiedURL($this->resources[$type]);
 
 		$protected64 = $this->base64url(json_encode($protected, JSON_UNESCAPED_SLASHES));
 		$payload64 = $this->base64url(is_string($payload) ? $payload : json_encode($payload, JSON_UNESCAPED_SLASHES));
@@ -296,8 +296,8 @@ class ACMEv2
 			$this->delay_until = null;
 		}
 
-        // 替换反向代理配置
-        $url = $this->proxiedURL($url);
+		// 替换反向代理配置
+		$url = $this->proxiedURL($url);
 
 		$method = $data === false ? 'HEAD' : ($data === null ? 'GET' : 'POST');
 		$user_agent = 'ACMECert v3.4.0 (+https://github.com/skoerfgen/ACMECert)';
@@ -421,29 +421,29 @@ class ACMEv2
 		);
 	}
 
-    // 替换反向代理配置
-    protected function proxiedURL($url)
-    {
-        if ($this->proxy == 2) {
-            return str_replace(
-                $this->proxy_config['origin'],
-                $this->proxy_config['proxy'],
-                $url
-            );
-        }
-        return $url;
-    }
+	// 替换反向代理配置
+	protected function proxiedURL($url)
+	{
+		if ($this->proxy == 2) {
+			return str_replace(
+				$this->proxy_config['origin'],
+				$this->proxy_config['proxy'],
+				$url
+			);
+		}
+		return $url;
+	}
 
-    // 反向替换反向代理配置
-    protected function unproxiedURL($url)
-    {
-        if ($this->proxy == 2) {
-            return str_replace(
-                $this->proxy_config['proxy'],
-                $this->proxy_config['origin'],
-                $url
-            );
-        }
-        return $url;
-    }
+	// 反向替换反向代理配置
+	protected function unproxiedURL($url)
+	{
+		if ($this->proxy == 2) {
+			return str_replace(
+				$this->proxy_config['proxy'],
+				$this->proxy_config['origin'],
+				$url
+			);
+		}
+		return $url;
+	}
 }

--- a/app/lib/acme/ACMEv2.php
+++ b/app/lib/acme/ACMEv2.php
@@ -8,13 +8,22 @@ class ACMEv2
 { // Communication with Let's Encrypt via ACME v2 protocol
 
 	protected
-		$ch = null, $logger = true, $bits, $sha_bits, $directory, $resources, $jwk_header, $kid_header, $account_key, $thumbprint, $nonce = null, $proxy;
+		$ch = null, $logger = true, $bits, $sha_bits, $directory, $resources, $jwk_header, $kid_header, $account_key, $thumbprint, $nonce = null, $proxy, $proxy_config = null;
 	private $delay_until = null;
 
-	public function __construct($directory, $proxy = false)
-	{
+    /**
+     * @param $directory string ACME directory URL
+     * @param $proxy int 代理模式，0为不使用代理，1为使用系统代理，2为使用反向代理
+     * @param null $proxy_config array 反向代理配置，proxy参数为2时必填
+     * @throws Exception
+     */
+	public function __construct($directory, $proxy = 0, $proxy_config = null)
+    {
 		$this->directory = $directory;
 		$this->proxy = $proxy;
+        if ($proxy == 2) {
+            $this->proxy_config = $proxy_config;
+        }
 	}
 
 	public function __destruct()
@@ -190,7 +199,8 @@ class ACMEv2
 		}
 
 		if (!$this->kid_header['kid'] && $type === 'newAccount') {
-			$this->kid_header['kid'] = $ret['headers']['location'];
+            // 反向替换反向代理配置，防止破坏签名
+            $this->kid_header['kid'] = $this->unproxiedURL($ret['headers']['location']);
 			$this->log('AccountID: ' . $this->kid_header['kid']);
 		}
 
@@ -218,7 +228,8 @@ class ACMEv2
 			throw new Exception('Resource "' . $type . '" not available.');
 		}
 
-		$protected['url'] = $this->resources[$type];
+		// 反向替换反向代理配置，防止破坏签名
+        $protected['url'] = $this->unproxiedURL($this->resources[$type]);
 
 		$protected64 = $this->base64url(json_encode($protected, JSON_UNESCAPED_SLASHES));
 		$payload64 = $this->base64url(is_string($payload) ? $payload : json_encode($payload, JSON_UNESCAPED_SLASHES));
@@ -284,6 +295,9 @@ class ACMEv2
 			}
 			$this->delay_until = null;
 		}
+
+        // 替换反向代理配置
+        $url = $this->proxiedURL($url);
 
 		$method = $data === false ? 'HEAD' : ($data === null ? 'GET' : 'POST');
 		$user_agent = 'ACMECert v3.4.0 (+https://github.com/skoerfgen/ACMECert)';
@@ -406,4 +420,30 @@ class ACMEv2
 			}, isset($error['subproblems']) ? $error['subproblems'] : array())
 		);
 	}
+
+    // 替换反向代理配置
+    protected function proxiedURL($url)
+    {
+        if ($this->proxy == 2) {
+            return str_replace(
+                $this->proxy_config['origin'],
+                $this->proxy_config['proxy'],
+                $url
+            );
+        }
+        return $url;
+    }
+
+    // 反向替换反向代理配置
+    protected function unproxiedURL($url)
+    {
+        if ($this->proxy == 2) {
+            return str_replace(
+                $this->proxy_config['proxy'],
+                $this->proxy_config['origin'],
+                $url
+            );
+        }
+        return $url;
+    }
 }

--- a/app/lib/cert/google.php
+++ b/app/lib/cert/google.php
@@ -9,8 +9,8 @@ use Exception;
 class google implements CertInterface
 {
     private $directories = array(
-        'live' => 'https://dv.acme-v02.api.pki.goog/directory',
-        'staging' => 'https://dv.acme-v02.test-api.pki.goog/directory'
+        'live' => 'https://dv.acme-v02.api.pki.goog',
+        'staging' => 'https://dv.acme-v02.test-api.pki.goog'
     );
     private $ac;
     private $config;
@@ -20,7 +20,11 @@ class google implements CertInterface
     {
         $this->config = $config;
         if (empty($config['mode'])) $config['mode'] = 'live';
-        $this->ac = new ACMECert($this->directories[$config['mode']], $config['proxy']==1);
+        if (empty($config['proxy_url'])) $config['proxy_url'] = '';
+        $this->ac = new ACMECert($this->directories[$config['mode']] . '/directory', (int)$config['proxy'], [
+            'origin' => $this->directories[$config['mode']],
+            'proxy' => rtrim($config['proxy_url'], '/'),
+        ]);
         if ($ext) {
             $this->ext = $ext;
             $this->ac->loadAccountKey($ext['key']);
@@ -31,16 +35,21 @@ class google implements CertInterface
     public function register()
     {
         if (empty($this->config['email'])) throw new Exception('邮件地址不能为空');
-        if (empty($this->config['kid']) || empty($this->config['key'])) throw new Exception('必填参数不能为空');
+
+        if (isset($this->config['eabMode']) && $this->config['eabMode'] == 'auto') {
+            $eab = $this->getEAB();
+        } else {
+            $eab = ['kid' => $this->config['kid'], 'key' => $this->config['key']];
+        }
 
         if (!empty($this->ext['key'])) {
-            $kid = $this->ac->registerEAB(true, $this->config['kid'], $this->config['key'], $this->config['email']);
+            $kid = $this->ac->registerEAB(true, $eab['kid'], $eab['key'], $this->config['email']);
             return ['kid' => $kid, 'key' => $this->ext['key']];
         }
 
         $key = $this->ac->generateRSAKey(2048);
         $this->ac->loadAccountKey($key);
-        $kid = $this->ac->registerEAB(true, $this->config['kid'], $this->config['key'], $this->config['email']);
+        $kid = $this->ac->registerEAB(true, $eab['kid'], $eab['key'], $this->config['email']);
         return ['kid' => $kid, 'key' => $key];
     }
 
@@ -114,5 +123,20 @@ class google implements CertInterface
     public function setLogger($func)
     {
         $this->ac->setLogger($func);
+    }
+
+    private function getEAB()
+    {
+        $api = "https://gts.rat.dev/eab";
+        $response = curl_client($api, null, null, null, null, $this->config['proxy'] == 1, 'GET', 10);
+        $result = json_decode($response['body'], true);
+        if (!isset($result['msg'])) {
+            throw new Exception('解析返回数据失败：' . $response['body']);
+        } elseif ($result['msg'] != 'success') {
+            throw new Exception('获取EAB失败：' . $result['msg']);
+        } elseif (empty($result['data']['key_id']) || empty($result['data']['mac_key'])) {
+            throw new Exception('获取EAB失败：返回数据不完整');
+        }
+        return ['kid' => $result['data']['key_id'], 'key' => $result['data']['mac_key']];
     }
 }


### PR DESCRIPTION
close #217
close #216 

搭建反向代理需要的nginx伪静态如下：

```nginx
resolver 8.8.8.8 ipv6=off valid=300s;
resolver_timeout 10s;

location / {
    set $empty "";
    proxy_pass https://dv.acme-v02.api.pki.goog$empty;
    proxy_set_header Accept-Encoding "";
    proxy_ssl_session_reuse off;
    proxy_ssl_server_name on;
    proxy_ssl_protocols TLSv1.2 TLSv1.3;
    proxy_http_version 1.1;

    sub_filter_once off;
    sub_filter_types *;
    sub_filter 'dv.acme-v02.api.pki.goog' 'gts.rat.dev'; # 替换自己的域名
}
```

以下是使用`https://gts.rat.dev`反向代理测试的截图。

<img width="1001" alt="iShot_2025-05-18_下午4 10 53" src="https://github.com/user-attachments/assets/95e07a75-a23f-4a65-a441-5a669fa8acc3" />
<img width="849" alt="iShot_2025-05-18_下午4 12 08" src="https://github.com/user-attachments/assets/9867a4fa-673d-4936-9f41-461d0bc8a608" />
<img width="929" alt="image" src="https://github.com/user-attachments/assets/0e805efb-49f9-4b74-898f-98dc707a35f8" />

