### PR TITLE
修复证书申请代理设置，使用反代时不使用代理

### DIFF
--- a/app/lib/acme/ACMEv2.php
+++ b/app/lib/acme/ACMEv2.php
@@ -321,7 +321,7 @@ class ACMEv2
 			}
 		));
 		
-		if ($this->proxy) {
+		if ($this->proxy == 1) {
 			curl_set_proxy($this->ch);
         }
 


### PR DESCRIPTION
证书申请使用反代域名时不应使用代理