### PR TITLE
将登录验证码开关移到系统设置

### DIFF
--- a/app/controller/System.php
+++ b/app/controller/System.php
@@ -28,6 +28,12 @@ class System extends BaseController
         return json(['code' => 0, 'msg' => 'succ']);
     }
 
+    public function loginset()
+    {
+        if (!checkPermission(2)) return $this->alert('error', '无权限');
+        return View::fetch();
+    }
+
     public function noticeset()
     {
         if (!checkPermission(2)) return $this->alert('error', '无权限');

--- a/app/view/common/layout.html
+++ b/app/view/common/layout.html
@@ -162,6 +162,7 @@
               </span>
             </a>
             <ul class="treeview-menu">
+              <li class="{:checkIfActive('loginset')}"><a href="/system/loginset"><i class="fa fa-circle-o"></i> 登录设置</a></li>
               <li class="{:checkIfActive('noticeset')}"><a href="/system/noticeset"><i class="fa fa-circle-o"></i> 通知设置</a></li>
               <li class="{:checkIfActive('proxyset')}"><a href="/system/proxyset"><i class="fa fa-circle-o"></i> 代理设置</a></li>
               <li><a href="https://www.showdoc.com.cn/dnsmgr/11058996709621562" target="_blank" rel="noreferrer"><i class="fa fa-circle-o"></i> <span>接口文档</span></a></li>

--- a/app/view/index/setpwd.html
+++ b/app/view/index/setpwd.html
@@ -7,21 +7,21 @@
 <div class="panel-heading"><h3 class="panel-title">修改密码</h3></div>
 <div class="panel-body">
   <form onsubmit="return saveAccount(this)" method="post" class="form" role="form">
-	<div class="form-group">
-	  <label>旧密码：</label>
-	  <input type="password" name="oldpwd" value="" class="form-control"  placeholder="请输入当前的密码" required/>
-	</div>
     <div class="form-group">
-	  <label>新密码：</label>
-	  <input type="password" name="newpwd" value="" class="form-control"  placeholder="" required/>
-	</div>
+      <label>旧密码：</label>
+      <input type="password" name="oldpwd" value="" class="form-control"  placeholder="请输入当前的密码" required/>
+    </div>
     <div class="form-group">
-	  <label>重输密码：</label>
-	  <input type="password" name="newpwd2" value="" class="form-control"  placeholder="" required/>
-	</div>
-	<div class="form-group text-center">
-	  <input type="submit" name="submit" value="确定" class="btn btn-success btn-block"/>
-	</div>
+      <label>新密码：</label>
+      <input type="password" name="newpwd" value="" class="form-control"  placeholder="" required/>
+    </div>
+    <div class="form-group">
+      <label>重输密码：</label>
+      <input type="password" name="newpwd2" value="" class="form-control"  placeholder="" required/>
+    </div>
+    <div class="form-group text-center">
+      <input type="submit" name="submit" value="确定" class="btn btn-success btn-block"/>
+    </div>
   </form>
 </div>
 </div>
@@ -29,18 +29,18 @@
 <div class="panel-heading"><h3 class="panel-title">TOTP二次验证</h3></div>
 <div class="panel-body">
   <form onsubmit="return saveAccount(this)" method="post" class="form" role="form">
-	<div class="form-group">
-		<div class="input-group">
-			{if $user.totp_open == 1}
-			<input type="text" name="totp_status" value="已开启" style="color:green" class="form-control" readonly/>
-			<div class="input-group-btn"><button type="button" class="btn btn-info" onclick="open_totp()">重置</button></div>
-			<div class="input-group-btn"><button type="button" class="btn btn-danger" onclick="close_totp()">关闭</button></div>
-			{else}
-			<input type="text" name="totp_status" value="未开启" style="color:blue" class="form-control" readonly/>
-			<div class="input-group-btn"><button type="button" class="btn btn-info" onclick="open_totp()">开启</button></div>
-			{/if}
-		</div>
-	</div>
+    <div class="form-group">
+        <div class="input-group">
+            {if $user.totp_open == 1}
+            <input type="text" name="totp_status" value="已开启" style="color:green" class="form-control" readonly/>
+            <div class="input-group-btn"><button type="button" class="btn btn-info" onclick="open_totp()">重置</button></div>
+            <div class="input-group-btn"><button type="button" class="btn btn-danger" onclick="close_totp()">关闭</button></div>
+            {else}
+            <input type="text" name="totp_status" value="未开启" style="color:blue" class="form-control" readonly/>
+            <div class="input-group-btn"><button type="button" class="btn btn-info" onclick="open_totp()">开启</button></div>
+            {/if}
+        </div>
+    </div>
   </form>
 </div>
 <div class="panel-footer">
@@ -49,39 +49,26 @@
 </div>
 </div>
 <div class="modal" id="modal-totp" data-backdrop="static" data-keyboard="false" aria-hidden="true">
-	<div class="modal-dialog" role="document">
-		<div class="modal-content">
-			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
-					<span aria-hidden="true">&times;</span>
-				</button>
-				<h4 class="modal-title">TOTP绑定</h4>
-			</div>
-			<div class="modal-body text-center">
-				<p>使用支持TOTP的认证软件扫描以下二维码</p>
-				<div class="qr-image mt-4" id="qrcode"></div>
-				<p><a href="javascript:;" data-clipboard-text="" id="copy-btn">复制密钥</a></p>
-				<form id="form-totp" style="text-align: left;" onsubmit="return bind_totp()">
-					<div class="form-group mt-4">
-						<div class="input-group"><input type="number" class="form-control input-lg" name="code" id="code" value="" placeholder="填写动态口令" autocomplete="off" required><div class="input-group-btn"><input type="submit" name="submit" value="完成绑定" class="btn btn-success btn-lg btn-block"/></div></div>
-					</div>
-				</form>
-			</div>
-		</div>
-	</div>
-</div>
-<div class="panel panel-info">
-<div class="panel-heading"><h3 class="panel-title">其他登录设置</h3></div>
-<div class="panel-body">
-  <form onsubmit="return saveAccount(this)" method="post" class="form-horizontal" role="form">
-	<div class="form-group">
-		<div class="form-group">
-			<label class="col-sm-3 control-label">开启图形验证码</label>
-			<div class="col-sm-9" style="margin-top:6.5px"><div class="material-switch"><input id="vocde_switch" type="checkbox" {if config_get('vcode', '1')=='1'}checked{/if} onchange="setvcode()"><label for="vocde_switch" class="label-primary"></label></div></div>
-		</div>
-	</div>
-  </form>
-</div>
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h4 class="modal-title">TOTP绑定</h4>
+            </div>
+            <div class="modal-body text-center">
+                <p>使用支持TOTP的认证软件扫描以下二维码</p>
+                <div class="qr-image mt-4" id="qrcode"></div>
+                <p><a href="javascript:;" data-clipboard-text="" id="copy-btn">复制密钥</a></p>
+                <form id="form-totp" style="text-align: left;" onsubmit="return bind_totp()">
+                    <div class="form-group mt-4">
+                        <div class="input-group"><input type="number" class="form-control input-lg" name="code" id="code" value="" placeholder="填写动态口令" autocomplete="off" required><div class="input-group-btn"><input type="submit" name="submit" value="完成绑定" class="btn btn-success btn-lg btn-block"/></div></div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
 </div>
 {/block}
 {block name="script"}
@@ -91,121 +78,110 @@
 <script>
 var commonData = {secret:null,qrcode:null};
 function saveAccount(obj){
-	var ii = layer.load(2, {shade:[0.1,'#fff']});
-	$.ajax({
-		type : 'POST',
-		url : '/setpwd',
-		data : $(obj).serialize(),
-		dataType : 'json',
-		success : function(data) {
-			layer.close(ii);
-			if(data.code == 0){
-				layer.alert('密码修改成功！请重新登录。', {
-					icon: 1,
-					closeBtn: false
-				}, function(){
-				  window.location.reload()
-				});
-			}else{
-				layer.alert(data.msg, {icon: 2})
-			}
-		},
-		error:function(data){
+    var ii = layer.load(2, {shade:[0.1,'#fff']});
+    $.ajax({
+        type : 'POST',
+        url : '/setpwd',
+        data : $(obj).serialize(),
+        dataType : 'json',
+        success : function(data) {
             layer.close(ii);
-			layer.msg('服务器错误');
-		}
-	});
-	return false;
+            if(data.code == 0){
+                layer.alert('密码修改成功！请重新登录。', {
+                    icon: 1,
+                    closeBtn: false
+                }, function(){
+                  window.location.reload()
+                });
+            }else{
+                layer.alert(data.msg, {icon: 2})
+            }
+        },
+        error:function(data){
+            layer.close(ii);
+            layer.msg('服务器错误');
+        }
+    });
+    return false;
 }
 function open_totp(){
-	if(!commonData.qrcode || !commonData.secret){
-		var ii = layer.load(2, {shade:[0.1,'#fff']});
-		$.post('/totp/generate', {}, function(res){
-			layer.close(ii);
-			if(res.code == 0){
-				commonData.secret = res.data.secret;
-				commonData.qrcode = res.data.qrcode;
-				$('#qrcode').qrcode({
-					text: commonData.qrcode,
-					width: 150,
-					height: 150,
-					foreground: "#000000",
-					background: "#ffffff",
-					typeNumber: -1
-				});
-				$("#copy-btn").attr('data-clipboard-text', commonData.secret);
-				$('#modal-totp').modal('show');
-				$("#code").focus();
-			}else{
-				layer.alert(res.msg, {icon: 2});
-			}
-		});
-	}else{
-		$('#modal-totp').modal('show');
-		$("#code").focus();
-	}
+    if(!commonData.qrcode || !commonData.secret){
+        var ii = layer.load(2, {shade:[0.1,'#fff']});
+        $.post('/totp/generate', {}, function(res){
+            layer.close(ii);
+            if(res.code == 0){
+                commonData.secret = res.data.secret;
+                commonData.qrcode = res.data.qrcode;
+                $('#qrcode').qrcode({
+                    text: commonData.qrcode,
+                    width: 150,
+                    height: 150,
+                    foreground: "#000000",
+                    background: "#ffffff",
+                    typeNumber: -1
+                });
+                $("#copy-btn").attr('data-clipboard-text', commonData.secret);
+                $('#modal-totp').modal('show');
+                $("#code").focus();
+            }else{
+                layer.alert(res.msg, {icon: 2});
+            }
+        });
+    }else{
+        $('#modal-totp').modal('show');
+        $("#code").focus();
+    }
 }
 function bind_totp(){
-	var code = $("#code").val();
-	if(code.length != 6){
-		layer.msg('动态口令格式错误', {icon: 2});
-		return false;
-	}
-	var ii = layer.load(2, {shade:[0.1,'#fff']});
-	$.post('/totp/bind', {secret:commonData.secret, code:code}, function(res){
-		layer.close(ii);
-		if(res.code == 0){
-			layer.alert('TOTP绑定成功', {icon: 1}, function(){
-				window.location.reload();
-			});
-		}else{
-			layer.alert(res.msg, {icon: 2});
-		}
-	});
-	return false;
+    var code = $("#code").val();
+    if(code.length != 6){
+        layer.msg('动态口令格式错误', {icon: 2});
+        return false;
+    }
+    var ii = layer.load(2, {shade:[0.1,'#fff']});
+    $.post('/totp/bind', {secret:commonData.secret, code:code}, function(res){
+        layer.close(ii);
+        if(res.code == 0){
+            layer.alert('TOTP绑定成功', {icon: 1}, function(){
+                window.location.reload();
+            });
+        }else{
+            layer.alert(res.msg, {icon: 2});
+        }
+    });
+    return false;
 }
 function close_totp(){
-	layer.confirm('确定要关闭TOTP二次验证吗？', {
-		btn: ['确定','取消']
-	}, function(){
-		var ii = layer.load(2, {shade:[0.1,'#fff']});
-		$.post('/totp/close', {}, function(res){
-			layer.close(ii);
-			if(res.code == 0){
-				layer.alert('TOTP已关闭', {icon: 1}, function(){
-					window.location.reload();
-				});
-			}else{
-				layer.alert(res.msg, {icon: 2});
-			}
-		});
-	});
-}
-function setvcode(){
-	var status = $("#vocde_switch").is(':checked') ? '1' : '2';
-	$.post('/system/set', {vcode: status}, function(res){
-		if(res.code == 0){
-			layer.msg(status == '1' ? '图形验证码已开启' : '图形验证码已关闭', {icon: 1, time: 1000});
-		}else{
-			layer.alert(res.msg, {icon: 2});
-			$("#vocde_switch").prop('checked', !status);
-		}
-	});
+    layer.confirm('确定要关闭TOTP二次验证吗？', {
+        btn: ['确定','取消']
+    }, function(){
+        var ii = layer.load(2, {shade:[0.1,'#fff']});
+        $.post('/totp/close', {}, function(res){
+            layer.close(ii);
+            if(res.code == 0){
+                layer.alert('TOTP已关闭', {icon: 1}, function(){
+                    window.location.reload();
+                });
+            }else{
+                layer.alert(res.msg, {icon: 2});
+            }
+        });
+    });
 }
 $(document).ready(function(){
-	var clipboard = new Clipboard('#copy-btn');
-	clipboard.on('success', function (e) {
-		layer.msg('复制成功！', {icon: 1, time: 600});
-	});
-	clipboard.on('error', function (e) {
-		layer.msg('复制失败', {icon: 2});
-	});
-	$("#code").keyup(function(){
-		var code = $(this).val();
-		if(code.length == 6){
-			$("#form-totp").submit();
-		}
-	});
+    var clipboard = new Clipboard('#copy-btn');
+    clipboard.on('success', function (e) {
+        layer.msg('复制成功！', {icon: 1, time: 600});
+    });
+    clipboard.on('error', function (e) {
+        layer.msg('复制失败', {icon: 2});
+    });
+    $("#code").keyup(function(){
+        var code = $(this).val();
+        if(code.length == 6){
+            $("#form-totp").submit();
+        }
+    });
 });
 </script>
 {/block}

--- a/app/view/system/loginset.html
+++ b/app/view/system/loginset.html
@@ -1,0 +1,35 @@
+{extend name="common/layout" /}
+{block name="title"}登录设置{/block}
+{block name="main"}
+<div class="row">
+<div class="col-xs-12 col-sm-8 col-lg-6 center-block" style="float: none;">
+<div class="panel panel-info">
+<div class="panel-heading"><h3 class="panel-title">登录验证码设置</h3></div>
+<div class="panel-body">
+    <div class="form-group">
+        <div class="form-group">
+            <label class="col-sm-3 control-label">开启图形验证码</label>
+            <div class="col-sm-9" style="margin-top:6.5px"><div class="material-switch"><input id="vocde_switch" type="checkbox" {if config_get('vcode', '1')=='1'}checked{/if} onchange="setvcode()"><label for="vocde_switch" class="label-primary"></label></div></div>
+        </div>
+    </div>
+</div>
+</div>
+{/block}
+{block name="script"}
+<script src="{$cdnpublic}layer/3.1.1/layer.js"></script>
+<script src="{$cdnpublic}jquery.qrcode/1.0/jquery.qrcode.min.js"></script>
+<script src="{$cdnpublic}clipboard.js/1.7.1/clipboard.min.js"></script>
+<script>
+function setvcode(){
+    var status = $("#vocde_switch").is(':checked') ? '1' : '2';
+    $.post('/system/set', {vcode: status}, function(res){
+        if(res.code == 0){
+            layer.msg(status == '1' ? '图形验证码已开启' : '图形验证码已关闭', {icon: 1, time: 1000});
+        }else{
+            layer.alert(res.msg, {icon: 2});
+            $("#vocde_switch").prop('checked', !status);
+        }
+    });
+}
+</script>
+{/block}

--- a/route/app.php
+++ b/route/app.php
@@ -112,6 +112,7 @@ Route::group(function () {
     
     Route::get('/cert/certset', 'cert/certset');
 
+    Route::get('/system/loginset', 'system/loginset');
     Route::get('/system/noticeset', 'system/noticeset');
     Route::get('/system/proxyset', 'system/proxyset');
     Route::post('/system/set', 'system/set');


### PR DESCRIPTION
登录验证码开关属于系统级配置，放在用户修改密码界面，且没有做权限管控，提供给所有用户可见不太合理（普通用户试图修改这个配置实际上也会报错）。故迁移到单独的登录设置页面。该页面还可以用于后续管理其他登录行为，比如控制登录失败次数（待实现）、配置强制所有用户开启TOTP等（待实现）。

![image](https://github.com/user-attachments/assets/467638bb-4ed6-4a33-9c78-07e3261546ea)
