### PR TITLE
修复网宿API验证失败的问题

### DIFF
--- a/app/lib/deploy/wangsu.php
+++ b/app/lib/deploy/wangsu.php
@@ -452,6 +452,9 @@ class wangsu implements DeployInterface
         } elseif (isset($result['message'])) {
             throw new Exception($result['message']);
 
+        } elseif (isset($result['result'])) {
+            throw new Exception($result['result']);
+
         } else {
             throw new Exception('请求失败');
         }


### PR DESCRIPTION
- [兼容网宿CDN接口使用result作为失败返回值的场景](https://github.com/HanadaLee/dnsmgr/commit/5b5e52cb8b4d517fd49d4f3c326ba5e654319b3f)

- [变更网宿check方法调用的API接口以避免产品未开通导致验证失败](https://github.com/HanadaLee/dnsmgr/commit/486ef4bcd5a378b292f8aac5bf99450d4f8bf0c1)