### PR TITLE
修复部署证书到阿里云和群晖失败的问题

### DIFF
--- a/app/common.php
+++ b/app/common.php
@@ -450,19 +450,25 @@ function http_request($url, $data = null, $referer = null, $cookie = null, $head
                     }
                 }
             } else if (is_array($data) || is_object($data)) {
-                if (!isset($options['headers']['Content-Type'])) {
-                    // 默认为表单
-                    $options['headers']['Content-Type'] = 'application/x-www-form-urlencoded';
-                }
-                if ($options['headers']['Content-Type'] == 'application/x-www-form-urlencoded') {
-                    // 表单
-                    $options['form_params'] = $data;
-                } else if ($options['headers']['Content-Type'] == 'application/json') {
-                    // json
-                    $options['json'] = $data;
+                if ($options['headers']['X-Content-Type'] == 'multipart/form-data') {
+                    // 表单文件
+                    unset($options['headers']['X-Content-Type'])
+                    $options['multipart'] = $data;
                 } else {
-                    // 其他
-                    $options['body'] = http_build_query($data);
+                    if (!isset($options['headers']['Content-Type'])) {
+                        // 默认为表单
+                        $options['headers']['Content-Type'] = 'application/x-www-form-urlencoded';
+                    }
+                    if ($options['headers']['Content-Type'] == 'application/x-www-form-urlencoded') {
+                        // 表单
+                        $options['form_params'] = $data;
+                    } else if ($options['headers']['Content-Type'] == 'application/json') {
+                        // json
+                        $options['json'] = $data;
+                    } else {
+                        // 其他
+                        $options['body'] = http_build_query($data);
+                    }
                 }
             } else {
                 $options['body'] = $data;

--- a/app/lib/deploy/aliyun.php
+++ b/app/lib/deploy/aliyun.php
@@ -101,7 +101,7 @@ class aliyun implements DeployInterface
         $cert_id = null;
         if ($data['TotalCount'] > 0 && !empty($data['CertificateOrderList'])) {
             foreach ($data['CertificateOrderList'] as $cert) {
-                if (strtolower($cert['SerialNo']) == $serial_no) {
+                if (strtolower($cert['SerialNo']) == $serial_no || strpos(strtolower($cert['SerialNo']), $serial_no) !== false) {
                     $cert_id = $cert['CertificateId'];
                     $cert_name = $cert['Name'];
                     break;


### PR DESCRIPTION
1、在生产环境中发现，从阿里云调用证书序列号时，阿里云可能会返回带有前置填充0的序列号
![50af8e5d0062a2374448bbcb5aa563e9](https://github.com/user-attachments/assets/faeb864e-9c66-41ad-9eda-54bae4adfb89)
![623484b7f69e3af7ba6d973dc2f0a6e5](https://github.com/user-attachments/assets/5310b490-992e-489b-bcaa-608e251cc7fc)
因此序列号比对改成泛匹配，以免对不上

2、https://github.com/netcccyun/dnsmgr/pull/236 重构了请求发送逻辑，改为使用Guzzle发送，但是群晖部署逻辑需要使用文件上传的方式发送POST请求，代码中使用了curl对象来处理，改为Guzzle后逻辑异常。本次修复在通用HTTP请求方法中增加了对表单文件的处理，重构了群晖的上传证书逻辑，适配Guzzle框架。
![image](https://github.com/user-attachments/assets/dd937118-cc4f-4756-8a48-e4ebc9149531)
