### PR TITLE
重构POST内容判断逻辑，去除X-Content-Type标头

### DIFF
--- a/app/common.php
+++ b/app/common.php
@@ -450,25 +450,23 @@ function http_request($url, $data = null, $referer = null, $cookie = null, $head
                     }
                 }
             } else if (is_array($data) || is_object($data)) {
-                if (isset($options['headers']['X-Content-Type']) && $options['headers']['X-Content-Type'] == 'multipart/form-data') {
+                if (!isset($options['headers']['Content-Type'])) {
+                    // 默认为表单
+                    $options['headers']['Content-Type'] = 'application/x-www-form-urlencoded';
+                }
+                if ($options['headers']['Content-Type'] == 'application/x-www-form-urlencoded') {
+                    // 表单
+                    $options['form_params'] = $data;
+                } else if ($options['headers']['Content-Type'] == 'multipart/form-data') {
                     // 表单文件
-                    unset($options['headers']['X-Content-Type']);
                     $options['multipart'] = $data;
+                    unset($options['headers']['Content-Type']); // 由GuzzleHttp重新生成Content-Type头部
+                } else if ($options['headers']['Content-Type'] == 'application/json') {
+                    // json
+                    $options['json'] = $data;
                 } else {
-                    if (!isset($options['headers']['Content-Type'])) {
-                        // 默认为表单
-                        $options['headers']['Content-Type'] = 'application/x-www-form-urlencoded';
-                    }
-                    if ($options['headers']['Content-Type'] == 'application/x-www-form-urlencoded') {
-                        // 表单
-                        $options['form_params'] = $data;
-                    } else if ($options['headers']['Content-Type'] == 'application/json') {
-                        // json
-                        $options['json'] = $data;
-                    } else {
-                        // 其他
-                        $options['body'] = http_build_query($data);
-                    }
+                    // 其他
+                    $options['body'] = http_build_query($data);
                 }
             } else {
                 $options['body'] = $data;

--- a/app/lib/deploy/synology.php
+++ b/app/lib/deploy/synology.php
@@ -110,7 +110,7 @@ class synology implements DeployInterface
             'SynoToken' => $this->token['synotoken'],
         ];
         $headers = [
-            'X-Content-Type' => 'multipart/form-data'
+            'Content-Type' => 'multipart/form-data'
         ];
         $post = [
             [


### PR DESCRIPTION
fix https://github.com/netcccyun/dnsmgr/issues/272

前面 https://github.com/netcccyun/dnsmgr/pull/270 为了修复群晖部署引入的X-Content-Type标头，目前看没什么必要，在http_request函数判断完之后直接unset掉Content-Type就可以了