### PR TITLE
fix: Passing null to parameter #5 ($passphrase) of type string is deprecated

### DIFF
--- a/app/lib/deploy/ssh.php
+++ b/app/lib/deploy/ssh.php
@@ -159,9 +159,8 @@ class ssh implements DeployInterface
             file_put_contents($privateKeyPath, $this->config['privatekey']);
             file_put_contents($publicKeyPath, $publicKey);
             umask($umask);
-            $passphrase = $this->config['passphrase'] ?? null; // 私钥密码
-            if ($passphrase) {
-                if (!ssh2_auth_pubkey_file($connection, $this->config['username'], $publicKeyPath, $privateKeyPath, $passphrase)) {
+            if (!empty($this->config['passphrase'])) {
+                if (!ssh2_auth_pubkey_file($connection, $this->config['username'], $publicKeyPath, $privateKeyPath, $this->config['passphrase'])) {
                     throw new Exception('私钥认证失败');
                 }
             } else {


### PR DESCRIPTION
Close #357 