### PR TITLE
fix: Cloudflare 增强快速添加 TXT 记录时未设置线路

### DIFF
--- a/app/controller/Cloudflare.php
+++ b/app/controller/Cloudflare.php
@@ -880,11 +880,16 @@ class Cloudflare extends BaseController
             'remark' => trim((string)($row['account_remark'] ?? '')),
         ];
         $accountType = trim((string)($row['account_type'] ?? ''));
+        $defaultLine = 'default';
+        if (isset(DnsHelper::$line_name[$accountType]['DEF'])) {
+            $defaultLine = strval(DnsHelper::$line_name[$accountType]['DEF']);
+        }
 
         return [
             'domain_id' => intval($row['id'] ?? 0),
             'domain_name' => trim((string)($row['name'] ?? '')),
             'record_name' => $recordName,
+            'default_line' => $defaultLine,
             'account_id' => $account['id'],
             'account_type' => $accountType,
             'account_type_name' => $this->formatDnsTypeName($accountType),

--- a/app/controller/Domain.php
+++ b/app/controller/Domain.php
@@ -558,6 +558,14 @@ class Domain extends BaseController
             return json(['code' => -1, 'msg' => '参数不能为空']);
         }
 
+        $dnstype = Db::name('account')->where('id', $drow['aid'])->value('type');
+        $defaultLine = isset(DnsHelper::$line_name[$dnstype]['DEF']) ? strval(DnsHelper::$line_name[$dnstype]['DEF']) : 'default';
+        if (isNullOrEmpty($line)) {
+            $line = $defaultLine;
+        } elseif ($line === '0' && $defaultLine !== '0') {
+            $line = $defaultLine;
+        }
+
         $dns = DnsHelper::getModel($drow['aid'], $drow['name'], $drow['thirdid']);
         $recordid = $dns->addDomainRecord($name, $type, $value, $line, $ttl, $mx, $weight, $remark);
         if ($recordid) {

--- a/app/view/cloudflare/hostnames.html
+++ b/app/view/cloudflare/hostnames.html
@@ -535,6 +535,10 @@ function buildQuickAddConfirmHtml(fullName, target){
 }
 
 function submitQuickAddTxtRecord(value, target){
+  var line = String((target && target.default_line) || '').trim();
+  if(!line){
+    line = 'default';
+  }
   var ii = layer.load(2);
   $.ajax({
     type: 'POST',
@@ -543,7 +547,7 @@ function submitQuickAddTxtRecord(value, target){
       name: target.record_name,
       type: 'TXT',
       value: value,
-      line: '0',
+      line: line,
       ttl: 600,
       mx: 1,
       weight: 0,


### PR DESCRIPTION
系统中已有动态设置默认线路 `default_line` 的能力, Cloudflare 增强功能没有用到此, 会导致一些提供商报错