### PR TITLE
feat(域名管理): 新增DNS检测工具功能

### DIFF
--- a/app/controller/Domain.php
+++ b/app/controller/Domain.php
@@ -8,6 +8,7 @@ use think\facade\View;
 use think\facade\Cache;
 use app\lib\DnsHelper;
 use app\service\ExpireNoticeService;
+use app\utils\DnsQueryUtils;
 use Exception;
 
 class Domain extends BaseController
@@ -1279,5 +1280,146 @@ class Domain extends BaseController
         if (!checkPermission(0, $drow['name'])) return json(['code' => -1, 'msg' => '无权限']);
         $result = (new ExpireNoticeService())->updateDomainDate($id, $drow['name']);
         return json($result);
+    }
+
+    public function record_check()
+    {
+        $id = input('param.id/d');
+        $drow = Db::name('domain')->where('id', $id)->find();
+        if (!$drow) {
+            return json(['code' => -1, 'msg' => '域名不存在']);
+        }
+        if (!checkPermission(0, $drow['name'])) return json(['code' => -1, 'msg' => '无权限']);
+
+        $recordid = input('post.recordid', null, 'trim');
+        $name = input('post.name', null, 'trim');
+        $type = input('post.type', null, 'trim');
+        $value = input('post.value', null, 'trim');
+
+        if (empty($recordid) || empty($name) || empty($type)) {
+            return json(['code' => -1, 'msg' => '参数不能为空']);
+        }
+
+        $domain = $name === '@' ? $drow['name'] : $name . '.' . $drow['name'];
+        $domain = strtolower($domain);
+
+        $supported_types = ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'SOA', 'SRV', 'CAA', 'PTR', 'LOC', 'LUA'];
+        if (!in_array($type, $supported_types)) {
+            return json(['code' => -1, 'msg' => '该记录类型暂不支持检测']);
+        }
+
+        $dns_records = DnsQueryUtils::get_dns_records($domain, $type);
+        if ($dns_records === false || empty($dns_records)) {
+            $dns_records = DnsQueryUtils::query_dns_doh($domain, $type);
+        }
+
+        if ($dns_records === false || empty($dns_records)) {
+            return json(['code' => 0, 'data' => ['status' => 'not_found', 'message' => '未查询到该解析记录', 'actual' => []]]);
+        }
+
+        $dns_records = array_map('strtolower', $dns_records);
+        $expected_value = strtolower(trim($value));
+
+        if (in_array($expected_value, $dns_records)) {
+            return json(['code' => 0, 'data' => ['status' => 'active', 'message' => '解析已生效', 'actual' => $dns_records]]);
+        } else {
+            return json(['code' => 0, 'data' => ['status' => 'mismatch', 'message' => '解析值不匹配', 'expected' => $expected_value, 'actual' => $dns_records]]);
+        }
+    }
+
+    public function dnscheck()
+    {
+        if (!checkPermission(1)) return $this->alert('error', '无权限');
+        
+        if (request()->isAjax()) {
+            $domain = input('post.domain', null, 'trim');
+            $type = input('post.type', null, 'trim');
+            $dns_server = input('post.dns_server', 'default', 'trim');
+            
+            if (empty($domain) || empty($type)) {
+                return json(['code' => -1, 'msg' => '域名和记录类型不能为空']);
+            }
+            
+            $domain = strtolower($domain);
+            
+            $supported_types = ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'SOA', 'SRV', 'CAA', 'PTR'];
+            if (!in_array($type, $supported_types)) {
+                return json(['code' => -1, 'msg' => '该记录类型暂不支持检测']);
+            }
+            
+            $result = $this->query_dns_with_server($domain, $type, $dns_server);
+            
+            return json($result);
+        }
+        
+        return view();
+    }
+    
+    private function query_dns_with_server($domain, $type, $dns_server)
+    {
+        $dns_servers = [
+            'alidns' => ['223.5.5.5', '223.6.6.6'],
+            'dnspod' => ['119.29.29.29', '182.254.116.116'],
+            'google' => ['8.8.8.8', '8.8.4.4'],
+            'cloudflare' => ['1.1.1.1', '1.0.0.1'],
+        ];
+        
+        $server_names = [
+            'default' => '系统默认',
+            'alidns' => '阿里DNS',
+            'dnspod' => 'DNSPod',
+            'google' => 'Google DNS',
+            'cloudflare' => 'Cloudflare',
+        ];
+        
+        if ($dns_server != 'default' && isset($dns_servers[$dns_server])) {
+            $records = $this->query_dns_custom_server($domain, $type, $dns_servers[$dns_server][0]);
+        } else {
+            $records = DnsQueryUtils::get_dns_records($domain, $type);
+            if ($records === false || empty($records)) {
+                $records = DnsQueryUtils::query_dns_doh($domain, $type);
+            }
+        }
+        
+        if ($records === false) {
+            return ['code' => 0, 'data' => ['status' => 'error', 'message' => '查询失败', 'dns_server' => $server_names[$dns_server] ?? $dns_server]];
+        }
+        
+        if (empty($records)) {
+            return ['code' => 0, 'data' => ['status' => 'not_found', 'message' => '未找到该类型的DNS记录', 'dns_server' => $server_names[$dns_server] ?? $dns_server]];
+        }
+        
+        return ['code' => 0, 'data' => ['status' => 'success', 'records' => $records, 'dns_server' => $server_names[$dns_server] ?? $dns_server]];
+    }
+    
+    private function query_dns_custom_server($domain, $type, $server)
+    {
+        $dns_type = ['A' => DNS_A, 'AAAA' => DNS_AAAA, 'CNAME' => DNS_CNAME, 'MX' => DNS_MX, 'TXT' => DNS_TXT, 'NS' => DNS_NS, 'SOA' => DNS_SOA, 'PTR' => DNS_PTR, 'SRV' => DNS_SRV, 'CAA' => DNS_CAA];
+        
+        if (!array_key_exists($type, $dns_type)) {
+            return false;
+        }
+        
+        try {
+            $cmd = 'dig +short +time=5 @' . escapeshellarg($server) . ' ' . escapeshellarg($domain) . ' ' . escapeshellarg($type) . ' 2>/dev/null';
+            $output = shell_exec($cmd);
+            
+            if (empty($output)) {
+                return false;
+            }
+            
+            $lines = explode("\n", trim($output));
+            $result = [];
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if (!empty($line)) {
+                    $result[] = $line;
+                }
+            }
+            
+            return empty($result) ? false : $result;
+        } catch (Exception $e) {
+            return false;
+        }
     }
 }

--- a/app/controller/Domain.php
+++ b/app/controller/Domain.php
@@ -158,8 +158,10 @@ class Domain extends BaseController
             }
             $accounts[] = ['id' => $row['id'], 'name' => $name, 'type' => DnsHelper::$dns_config[$row['type']]['name'], 'add' => DnsHelper::$dns_config[$row['type']]['add']];
         }
+        $categorys = Db::name('domain_category')->order('sort', 'asc')->order('id', 'desc')->select();
         View::assign('accounts', $accounts);
         View::assign('types', $types);
+        View::assign('categorys', $categorys);
         return view();
     }
 
@@ -189,6 +191,7 @@ class Domain extends BaseController
         $kw = input('post.kw', null, 'trim');
         $type = input('post.type', null, 'trim');
         $status = input('post.status', null, 'trim');
+        $cid = input('post.cid', null, 'trim');
         $order = input('post.order', null, 'trim');
         $offset = input('post.offset/d', 0);
         $limit = input('post.limit/d', 10);
@@ -206,6 +209,9 @@ class Domain extends BaseController
         }
         if (!empty($type)) {
             $select->whereLike('B.type', $type);
+        }
+        if (!isNullOrEmpty($cid)) {
+            $select->where('A.cid', $cid);
         }
         if (request()->user['level'] == 1) {
             $select->where('is_hide', 0)->where('A.name', 'in', request()->user['permission']);
@@ -236,10 +242,12 @@ class Domain extends BaseController
         }
         $rows = $select->fieldRaw('A.*,B.type,B.remark aremark')->limit($offset, $limit)->select();
 
+        $categorys = Db::name('domain_category')->column('name', 'id');
         $list = [];
         foreach ($rows as $row) {
             $row['typename'] = DnsHelper::$dns_config[$row['type']]['name'];
             $row['icon'] = DnsHelper::$dns_config[$row['type']]['icon'];
+            $row['category_name'] = isset($categorys[$row['cid']]) ? $categorys[$row['cid']] : '';
             $list[] = $row;
         }
 
@@ -291,6 +299,7 @@ class Domain extends BaseController
             $is_hide = input('post.is_hide/d');
             $is_sso = input('post.is_sso/d');
             $is_notice = input('post.is_notice/d');
+            $cid = input('post.cid/d', 0);
             $expiretime = input('post.expiretime', null, 'trim');
             $remark = input('post.remark', null, 'trim');
             if (empty($remark)) $remark = null;
@@ -298,6 +307,7 @@ class Domain extends BaseController
                 'is_hide' => $is_hide,
                 'is_sso' => $is_sso,
                 'is_notice' => $is_notice,
+                'cid' => $cid,
                 'expiretime' => $expiretime ? $expiretime : null,
                 'remark' => $remark,
             ]);
@@ -1421,5 +1431,94 @@ class Domain extends BaseController
         } catch (Exception $e) {
             return false;
         }
+    }
+
+    public function category()
+    {
+        if (!checkPermission(2)) return $this->alert('error', '无权限');
+        return view();
+    }
+
+    public function category_data()
+    {
+        if (!checkPermission(2)) return json(['total' => 0, 'rows' => []]);
+        $offset = input('post.offset/d', 0);
+        $limit = input('post.limit/d', 10);
+
+        $select = Db::name('domain_category');
+        $total = $select->count();
+        $rows = $select->order('sort', 'asc')->order('id', 'desc')->limit($offset, $limit)->select()->toArray();
+
+        foreach ($rows as &$row) {
+            $row['domain_count'] = Db::name('domain')->where('cid', $row['id'])->count();
+        }
+
+        return json(['total' => $total, 'rows' => $rows]);
+    }
+
+    public function category_op()
+    {
+        if (!checkPermission(2)) return json(['code' => -1, 'msg' => '无权限']);
+        $action = input('param.action');
+        if ($action == 'add') {
+            $name = input('post.name', null, 'trim');
+            $remark = input('post.remark', null, 'trim');
+            $sort = input('post.sort/d', 0);
+            if (empty($name)) return json(['code' => -1, 'msg' => '分类名称不能为空']);
+            if (Db::name('domain_category')->where('name', $name)->find()) {
+                return json(['code' => -1, 'msg' => '分类名称已存在']);
+            }
+            Db::name('domain_category')->insert([
+                'name' => $name,
+                'remark' => $remark,
+                'sort' => $sort,
+                'addtime' => date('Y-m-d H:i:s'),
+            ]);
+            return json(['code' => 0, 'msg' => '添加分类成功！']);
+        } elseif ($action == 'edit') {
+            $id = input('post.id/d');
+            $row = Db::name('domain_category')->where('id', $id)->find();
+            if (!$row) return json(['code' => -1, 'msg' => '分类不存在']);
+            $name = input('post.name', null, 'trim');
+            $remark = input('post.remark', null, 'trim');
+            $sort = input('post.sort/d', 0);
+            if (empty($name)) return json(['code' => -1, 'msg' => '分类名称不能为空']);
+            if (Db::name('domain_category')->where('name', $name)->where('id', '<>', $id)->find()) {
+                return json(['code' => -1, 'msg' => '分类名称已存在']);
+            }
+            Db::name('domain_category')->where('id', $id)->update([
+                'name' => $name,
+                'remark' => $remark,
+                'sort' => $sort,
+            ]);
+            return json(['code' => 0, 'msg' => '修改分类成功！']);
+        } elseif ($action == 'del') {
+            $id = input('post.id/d');
+            $count = Db::name('domain')->where('cid', $id)->count();
+            if ($count > 0) return json(['code' => -1, 'msg' => '该分类下存在域名，无法删除']);
+            Db::name('domain_category')->where('id', $id)->delete();
+            return json(['code' => 0, 'msg' => '删除分类成功！']);
+        }
+        return json(['code' => -3]);
+    }
+
+    public function category_list()
+    {
+        if (!checkPermission(2)) return json(['code' => -1, 'msg' => '无权限']);
+        $list = Db::name('domain_category')->order('sort', 'asc')->order('id', 'desc')->select();
+        foreach ($list as &$row) {
+            $row['domain_count'] = Db::name('domain')->where('cid', $row['id'])->count();
+        }
+        return json(['code' => 0, 'data' => $list]);
+    }
+
+    public function domain_set_category()
+    {
+        if (!checkPermission(2)) return json(['code' => -1, 'msg' => '无权限']);
+        $ids = input('post.ids');
+        $cid = input('post.cid/d', 0);
+        if (empty($ids)) return json(['code' => -1, 'msg' => '请选择要操作的域名']);
+        $count = Db::name('domain')->where('id', 'in', $ids)->update(['cid' => $cid]);
+        return json(['code' => 0, 'msg' => '成功设置' . $count . '个域名的分类！']);
     }
 }

--- a/app/sql/install.sql
+++ b/app/sql/install.sql
@@ -5,7 +5,7 @@ CREATE TABLE `dnsmgr_config` (
   PRIMARY KEY (`key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-INSERT INTO `dnsmgr_config` VALUES ('version', '1048');
+INSERT INTO `dnsmgr_config` VALUES ('version', '1049');
 INSERT INTO `dnsmgr_config` VALUES ('notice_mail', '0');
 INSERT INTO `dnsmgr_config` VALUES ('notice_wxtpl', '0');
 INSERT INTO `dnsmgr_config` VALUES ('mail_smtp', 'smtp.qq.com');
@@ -26,6 +26,7 @@ DROP TABLE IF EXISTS `dnsmgr_domain`;
 CREATE TABLE `dnsmgr_domain` (
   `id` int(11) unsigned NOT NULL auto_increment,
   `aid` int(11) unsigned NOT NULL,
+  `cid` int(11) unsigned NOT NULL DEFAULT '0',
   `name` varchar(255) NOT NULL,
   `thirdid` varchar(60) DEFAULT NULL,
   `addtime` datetime DEFAULT NULL,
@@ -40,7 +41,8 @@ CREATE TABLE `dnsmgr_domain` (
   `noticetime` datetime DEFAULT NULL,
   `checkstatus` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `name` (`name`)
+  KEY `name` (`name`),
+  KEY `cid` (`cid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS `dnsmgr_user`;
@@ -261,4 +263,15 @@ CREATE TABLE `dnsmgr_domain_alias` (
   PRIMARY KEY (`id`),
   KEY `did` (`did`),
   KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+DROP TABLE IF EXISTS `dnsmgr_domain_category`;
+CREATE TABLE `dnsmgr_domain_category` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `name` varchar(50) NOT NULL,
+  `remark` varchar(100) DEFAULT NULL,
+  `sort` int(11) NOT NULL DEFAULT '0',
+  `addtime` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `sort` (`sort`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/app/sql/update.sql
+++ b/app/sql/update.sql
@@ -199,3 +199,17 @@ CREATE TABLE IF NOT EXISTS `dnsmgr_domain_alias` (
   KEY `did` (`did`),
   KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `dnsmgr_domain_category` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `name` varchar(50) NOT NULL,
+  `remark` varchar(100) DEFAULT NULL,
+  `sort` int(11) NOT NULL DEFAULT '0',
+  `addtime` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `sort` (`sort`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE `dnsmgr_domain`
+ADD COLUMN `cid` int(11) unsigned NOT NULL DEFAULT '0',
+ADD KEY `cid` (`cid`);

--- a/app/view/common/layout.html
+++ b/app/view/common/layout.html
@@ -109,6 +109,9 @@
           <li class="{:checkIfActive('domain,record,record_log,record_batch_add,domain_add,weight,record_batch_add2,record_batch_edit2,expire_notice,smartparse')}">
             <a href="/domain"><i class="fa fa-list-ul fa-fw"></i> <span>域名管理</span></a>
           </li>
+          <li class="{:checkIfActive('dnscheck')}">
+            <a href="/domain/dnscheck"><i class="fa fa-search fa-fw"></i> <span>DNS检测工具</span></a>
+          </li>
           <li class="{:checkIfActive('smartparse')}">
             <a href="/record/smartparse"><i class="fa fa-magic fa-fw"></i> <span>智能解析</span></a>
           </li>

--- a/app/view/common/layout.html
+++ b/app/view/common/layout.html
@@ -119,6 +119,9 @@
           <li class="{:checkIfActive('account,account_add')}">
             <a href="/account"><i class="fa fa-lock fa-fw"></i> <span>域名账户</span></a>
           </li>
+          <li class="{:checkIfActive('category')}">
+            <a href="/domain/category"><i class="fa fa-folder fa-fw"></i> <span>域名分类</span></a>
+          </li>
           <li class="treeview {:checkIfActive('overview,task,taskinfo,taskform')}">
             <a href="javascript:;">
               <i class="fa fa-heartbeat fa-fw"></i>

--- a/app/view/domain/dnscheck.html
+++ b/app/view/domain/dnscheck.html
@@ -1,0 +1,262 @@
+{extend name="common/layout" /}
+{block name="title"}DNS解析检测工具{/block}
+{block name="main"}
+<style>
+.result-box {
+    margin-top: 20px;
+}
+.result-item {
+    padding: 15px;
+    margin-bottom: 15px;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+}
+.result-success {
+    background-color: #f0f9eb;
+    border-color: #67c23a;
+}
+.result-warning {
+    background-color: #fdf6ec;
+    border-color: #e6a23c;
+}
+.result-error {
+    background-color: #fef0f0;
+    border-color: #f56c6c;
+}
+.result-title {
+    font-weight: bold;
+    margin-bottom: 10px;
+    font-size: 16px;
+}
+.result-content {
+    color: #666;
+}
+.result-content ul {
+    margin: 5px 0;
+    padding-left: 20px;
+}
+.result-content li {
+    margin: 3px 0;
+    word-break: break-all;
+}
+.dns-server-tag {
+    display: inline-block;
+    padding: 2px 8px;
+    margin: 2px;
+    background-color: #f0f0f0;
+    border-radius: 3px;
+    font-size: 12px;
+}
+</style>
+<div class="row">
+    <div class="col-xs-12 center-block" style="float: none;">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">DNS解析检测工具</h3>
+            </div>
+            <div class="panel-body">
+                <form class="form-horizontal" id="checkForm">
+                    <div class="form-group">
+                        <label class="col-sm-2 control-label">域名</label>
+                        <div class="col-sm-8">
+                            <input type="text" class="form-control" name="domain" placeholder="输入要检测的域名，例如：www.example.com" required>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-sm-2 control-label">记录类型</label>
+                        <div class="col-sm-8">
+                            <select name="type" class="form-control">
+                                <option value="A">A (IPv4地址)</option>
+                                <option value="AAAA">AAAA (IPv6地址)</option>
+                                <option value="CNAME">CNAME (别名记录)</option>
+                                <option value="MX">MX (邮件交换)</option>
+                                <option value="TXT">TXT (文本记录)</option>
+                                <option value="NS">NS (域名服务器)</option>
+                                <option value="SOA">SOA (起始授权)</option>
+                                <option value="SRV">SRV (服务定位)</option>
+                                <option value="CAA">CAA (证书授权)</option>
+                                <option value="PTR">PTR (反向解析)</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-sm-2 control-label">DNS服务器</label>
+                        <div class="col-sm-8">
+                            <label class="radio-inline">
+                                <input type="radio" name="dns_server" value="default" checked> 系统默认
+                            </label>
+                            <label class="radio-inline">
+                                <input type="radio" name="dns_server" value="alidns"> 阿里DNS
+                            </label>
+                            <label class="radio-inline">
+                                <input type="radio" name="dns_server" value="dnspod"> DNSPod
+                            </label>
+                            <label class="radio-inline">
+                                <input type="radio" name="dns_server" value="google"> Google DNS
+                            </label>
+                            <label class="radio-inline">
+                                <input type="radio" name="dns_server" value="cloudflare"> Cloudflare
+                            </label>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-sm-offset-2 col-sm-8">
+                            <button type="submit" class="btn btn-primary" id="checkBtn">
+                                <i class="fa fa-search"></i> 开始检测
+                            </button>
+                            <button type="button" class="btn btn-default" onclick="clearResult()">
+                                <i class="fa fa-trash"></i> 清空结果
+                            </button>
+                        </div>
+                    </div>
+                </form>
+
+                <div id="resultBox" class="result-box" style="display:none;">
+                    <div class="form-group">
+                        <label class="col-sm-2 control-label">检测结果</label>
+                        <div class="col-sm-8" id="resultContent">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">使用说明</h3>
+            </div>
+            <div class="panel-body">
+                <ul>
+                    <li><strong>A记录</strong>：检测域名解析到的IPv4地址</li>
+                    <li><strong>AAAA记录</strong>：检测域名解析到的IPv6地址</li>
+                    <li><strong>CNAME记录</strong>：检测域名的别名指向</li>
+                    <li><strong>MX记录</strong>：检测邮件服务器配置</li>
+                    <li><strong>TXT记录</strong>：检测文本记录内容（常用于SPF、DKIM验证）</li>
+                    <li><strong>NS记录</strong>：检测域名的DNS服务器</li>
+                    <li><strong>SOA记录</strong>：检测域名的授权信息</li>
+                    <li><strong>SRV记录</strong>：检测服务定位记录</li>
+                    <li><strong>CAA记录</strong>：检测证书颁发机构授权</li>
+                    <li><strong>PTR记录</strong>：检测反向解析记录</li>
+                </ul>
+                <p class="text-muted">提示：可以选择不同的DNS服务器来检测解析是否在全球生效。</p>
+            </div>
+        </div>
+    </div>
+</div>
+{/block}
+{block name="script"}
+<script src="/static/js/layer/layer.js"></script>
+<script>
+$(document).ready(function(){
+    $('#checkForm').on('submit', function(e){
+        e.preventDefault();
+        doCheck();
+    });
+});
+
+function doCheck(){
+    var domain = $('input[name="domain"]').val().trim();
+    var type = $('select[name="type"]').val();
+    var dnsServer = $('input[name="dns_server"]:checked').val();
+    
+    if(!domain){
+        layer.msg('请输入域名', {icon: 2});
+        return;
+    }
+    
+    $('#checkBtn').prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> 检测中...');
+    
+    $.ajax({
+        type: 'POST',
+        url: '/domain/dnscheck',
+        data: {
+            domain: domain,
+            type: type,
+            dns_server: dnsServer
+        },
+        dataType: 'json',
+        success: function(data){
+            $('#checkBtn').prop('disabled', false).html('<i class="fa fa-search"></i> 开始检测');
+            if(data.code == 0){
+                showResult(data.data, domain, type);
+            }else{
+                layer.alert(data.msg, {icon: 2});
+            }
+        },
+        error: function(){
+            $('#checkBtn').prop('disabled', false).html('<i class="fa fa-search"></i> 开始检测');
+            layer.msg('请求失败，请稍后重试', {icon: 2});
+        }
+    });
+}
+
+function showResult(result, domain, type){
+    var html = '';
+    var statusClass = '';
+    var statusTitle = '';
+    var statusIcon = '';
+    
+    if(result.status == 'success'){
+        statusClass = 'result-success';
+        statusTitle = '查询成功';
+        statusIcon = '<i class="fa fa-check-circle text-success"></i> ';
+    }else if(result.status == 'not_found'){
+        statusClass = 'result-warning';
+        statusTitle = '未找到记录';
+        statusIcon = '<i class="fa fa-exclamation-circle text-warning"></i> ';
+    }else{
+        statusClass = 'result-error';
+        statusTitle = '查询失败';
+        statusIcon = '<i class="fa fa-times-circle text-danger"></i> ';
+    }
+    
+    html += '<div class="result-item ' + statusClass + '">';
+    html += '<div class="result-title">' + statusIcon + statusTitle + '</div>';
+    html += '<div class="result-content">';
+    html += '<p><strong>查询域名：</strong>' + htmlEscape(domain) + '</p>';
+    html += '<p><strong>记录类型：</strong>' + type + '</p>';
+    
+    if(result.dns_server){
+        html += '<p><strong>DNS服务器：</strong><span class="dns-server-tag">' + htmlEscape(result.dns_server) + '</span></p>';
+    }
+    
+    if(result.records && result.records.length > 0){
+        html += '<p><strong>解析结果：</strong></p>';
+        html += '<ul>';
+        for(var i = 0; i < result.records.length; i++){
+            html += '<li>' + htmlEscape(result.records[i]) + '</li>';
+        }
+        html += '</ul>';
+    }
+    
+    if(result.ttl){
+        html += '<p><strong>TTL：</strong>' + result.ttl + ' 秒</p>';
+    }
+    
+    if(result.message && result.status != 'success'){
+        html += '<p><strong>提示：</strong>' + htmlEscape(result.message) + '</p>';
+    }
+    
+    html += '</div>';
+    html += '</div>';
+    
+    $('#resultContent').html(html);
+    $('#resultBox').show();
+}
+
+function clearResult(){
+    $('#resultContent').html('');
+    $('#resultBox').hide();
+    $('input[name="domain"]').val('');
+}
+
+function htmlEscape(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+</script>
+{/block}

--- a/app/view/domain/domain.html
+++ b/app/view/domain/domain.html
@@ -107,12 +107,23 @@
 						</div>
 					</div>
 					<div class="form-group">
-						<label class="col-sm-3 control-label no-padding-right">备注</label>
-						<div class="col-sm-9">
-							<input type="text" class="form-control" name="remark" placeholder="">
-						</div>
+					<label class="col-sm-3 control-label">所属分类</label>
+					<div class="col-sm-9">
+						<select name="cid" class="form-control">
+							<option value="0">未分类</option>
+							{foreach $categorys as $item}
+							<option value="{$item.id}">{$item.name}</option>
+							{/foreach}
+						</select>
 					</div>
-				</form>
+				</div>
+				<div class="form-group">
+					<label class="col-sm-3 control-label no-padding-right">备注</label>
+					<div class="col-sm-9">
+						<input type="text" class="form-control" name="remark" placeholder="">
+					</div>
+				</div>
+			</form>
 			</div>
 			<div class="modal-footer">
 				<button type="button" class="btn btn-white" data-dismiss="modal">关闭</button>
@@ -139,6 +150,9 @@
 	{/foreach}</select>
   </div>
   <div class="form-group">
+	<select name="cid" class="form-control"><option value="">所有分类</option>{foreach $categorys as $item}<option value="{$item.id}">{$item.name}</option>{/foreach}</select>
+  </div>
+  <div class="form-group">
 	<select name="status" class="form-control"><option value="">所有状态</option><option value="1">即将到期</option><option value="2">已到期</option></select>
   </div>
   <div class="form-group">
@@ -149,7 +163,7 @@
   {if $user['level'] eq 2}<a href="javascript:addframe()" class="btn btn-success"><i class="fa fa-plus"></i> 添加</a>
   <div class="btn-group" role="group">
 	<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">批量操作 <span class="caret"></span></button>
-	<ul class="dropdown-menu"><li><a href="/domain/add">添加域名</a></li><li><a href="javascript:operation('editremark')">修改域名备注</a></li><li><a href="javascript:operation('opennotice')">开启到期提醒</a></li><li><a href="javascript:operation('closenotice')">关闭到期提醒</a></li><li><a href="javascript:operation('updateexpire')">刷新到期时间</a></li><li><a href="javascript:operation('delete')">删除域名</a></li><li role="separator" class="divider"></li><li><a href="javascript:operation('addrecord')">添加解析</a></li><li><a href="javascript:operation('editrecord')">修改解析</a></li></ul>
+	<ul class="dropdown-menu"><li><a href="/domain/add">添加域名</a></li><li><a href="javascript:operation('setcategory')">设置分类</a></li><li><a href="javascript:operation('editremark')">修改域名备注</a></li><li><a href="javascript:operation('opennotice')">开启到期提醒</a></li><li><a href="javascript:operation('closenotice')">关闭到期提醒</a></li><li><a href="javascript:operation('updateexpire')">刷新到期时间</a></li><li><a href="javascript:operation('delete')">删除域名</a></li><li role="separator" class="divider"></li><li><a href="javascript:operation('addrecord')">添加解析</a></li><li><a href="javascript:operation('editrecord')">修改解析</a></li></ul>
   </div>
   <a href="/domain/expirenotice" class="btn btn-default">到期提醒设置</a>{/if}
 </form>
@@ -199,6 +213,13 @@ $(document).ready(function(){
 				title: '平台账户',
 				formatter: function(value, row, index) {
 					return '<img src="/static/images/'+row.icon+'" class="type-logo"></img>'+(row.aremark?row.aremark:value+'('+row.aid+')');
+				}
+			},
+			{
+				field: 'category_name',
+				title: '分类',
+				formatter: function(value, row, index) {
+					return value ? '<span class="label label-primary">' + value + '</span>' : '-';
 				}
 			},
             {
@@ -400,6 +421,7 @@ function editframe(id){
 	$("#form-store2 select[name=is_hide]").val(row.is_hide);
 	$("#form-store2 select[name=is_sso]").val(row.is_sso);
 	$("#form-store2 select[name=is_notice]").val(row.is_notice);
+	$("#form-store2 select[name=cid]").val(row.cid ? row.cid : 0);
 	$("#form-store2 input[name=remark]").val(row.remark);
 
 	$("#form-store2 input[name=expiretime]").datetimepicker({
@@ -504,6 +526,9 @@ function operation(action){
 	if(action == 'editremark'){
 		batch_edit_remark(ids)
 		return;
+	}else if(action == 'setcategory'){
+		batch_set_category(ids)
+		return;
 	}else if(action == 'addrecord'){
 		sessionStorage.setItem('domains', JSON.stringify(rows));
 		window.location.href = '/record/batchadd';
@@ -588,6 +613,56 @@ function batch_edit_remark(ids) {
 				type : 'POST',
 				url : '/domain/op/act/batchedit',
 				data : {ids:ids, remark:remark},
+				dataType : 'json',
+				success : function(data) {
+					layer.close(ii);
+					layer.alert(data.msg,{
+						icon: 1,
+						closeBtn: false
+					}, function(){
+						layer.closeAll();
+						searchRefresh();
+					});
+				},
+				error:function(data){
+					layer.close(ii);
+					layer.msg('服务器错误');
+				}
+			});
+		}
+	});
+}
+
+function batch_set_category(ids) {
+	var categoryOptions = '<option value="0">未分类</option>';
+	$.ajax({
+		type : 'GET',
+		url : '/domain/category/list',
+		dataType : 'json',
+		async: false,
+		success : function(data) {
+			if(data.code == 0 && data.data){
+				$.each(data.data, function(index, item){
+					categoryOptions += '<option value="' + item.id + '">' + item.name + '</option>';
+				});
+			}
+		}
+	});
+	
+	layer.open({
+		type: 1,
+		area: ['350px'],
+		closeBtn: 2,
+		title: '批量设置分类',
+		content: '<div style="padding:15px"><div class="form-group"><select class="form-control" name="category_id">' + categoryOptions + '</select></div></div>',
+		btn: ['确认', '取消'],
+		yes: function(){
+			var cid = $("select[name='category_id']").val();
+			var ii = layer.load(2, {shade:[0.1,'#fff']});
+			$.ajax({
+				type : 'POST',
+				url : '/domain/setcategory',
+				data : {ids:ids, cid:cid},
 				dataType : 'json',
 				success : function(data) {
 					layer.close(ii);

--- a/app/view/domain/record.html
+++ b/app/view/domain/record.html
@@ -350,6 +350,10 @@ $(document).ready(function(){
 					if(dnsconfig.remark == 1){
 						html += '<a href="javascript:setRemark(\''+row.RecordId+'\')" class="btn btn-info btn-xs">备注</a>&nbsp;&nbsp;';
 					}
+					var supportedTypes = ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'SOA', 'SRV', 'CAA', 'PTR', 'LOC', 'LUA', 'REDIRECT_URL', 'FORWARD_URL'];
+					if(supportedTypes.includes(row.Type)){
+						html += '<a href="javascript:checkRecord(\''+row.RecordId+'\')" class="btn btn-success btn-xs" title="检测解析生效"><i class="fa fa-check-circle-o"></i></a>&nbsp;&nbsp;';
+					}
 					if(row.Type == 'A' || row.Type == 'CNAME' || row.Type == 'AAAA' || row.Type == 'REDIRECT_URL' || row.Type == 'FORWARD_URL'){
 						if(row.Name === "@") var domain = "{$domainName}";
 						else var domain = row.Name + ".{$domainName}";
@@ -724,6 +728,49 @@ function advanceSearch(){
 		$("#searchbox2").slideUp();
 		$("#searchbox1").slideDown();
 	}
+}
+function checkRecord(recordid) {
+	var row = $("#listTable").bootstrapTable('getRowByUniqueId', recordid);
+	var ii = layer.load(2);
+	$.ajax({
+		type : 'POST',
+		url : '/record/check/{$domainId}',
+		data : {recordid: recordid, name: row.Name, type: row.Type, value: row.Value},
+		dataType : 'json',
+		success : function(data) {
+			layer.close(ii);
+			if(data.code == 0){
+				var result = data.data;
+				var icon = result.status === 'active' ? 1 : (result.status === 'not_found' ? 0 : 2);
+				var title = result.status === 'active' ? '解析已生效' : (result.status === 'not_found' ? '未查询到解析' : '解析值不匹配');
+				var content = '<div style="padding:15px;">';
+				content += '<p><strong>主机记录：</strong>' + row.Name + '</p>';
+				content += '<p><strong>记录类型：</strong>' + row.Type + '</p>';
+				content += '<p><strong>记录值：</strong>' + htmlEscape(row.Value) + '</p>';
+				content += '<hr style="margin:10px 0;">';
+				content += '<p><strong>检测结果：</strong>' + result.message + '</p>';
+				if(result.actual && result.actual.length > 0){
+					content += '<p><strong>实际解析值：</strong></p>';
+					content += '<ul style="max-height:150px;overflow-y:auto;">';
+					for(var i = 0; i < result.actual.length; i++){
+						content += '<li>' + htmlEscape(result.actual[i]) + '</li>';
+					}
+					content += '</ul>';
+				}
+				if(result.expected){
+					content += '<p><strong>期望解析值：</strong>' + htmlEscape(result.expected) + '</p>';
+				}
+				content += '</div>';
+				layer.alert(content, {title: title, icon: icon, area: ['450px']});
+			}else{
+				layer.alert(data.msg, {icon: 2});
+			}
+		},
+		error: function(){
+			layer.close(ii);
+			layer.msg('服务器错误', {icon: 2});
+		}
+	});
 }
 function copyToClipboard(text, selector) {
     if (!text && selector) {

--- a/config/app.php
+++ b/config/app.php
@@ -33,5 +33,5 @@ return [
 
     'version' => '1049',
 
-    'dbversion' => '1048'
+    'dbversion' => '1049'
 ];

--- a/route/app.php
+++ b/route/app.php
@@ -87,7 +87,12 @@ Route::group(function () {
     Route::post('/domain/op', 'domain/domain_op');
     Route::post('/domain/list', 'domain/domain_list');
     Route::any('/domain/dnscheck', 'domain/dnscheck');
+    Route::post('/domain/category/data', 'domain/category_data');
+    Route::post('/domain/category/:action', 'domain/category_op');
+    Route::get('/domain/category/list', 'domain/category_list');
+    Route::post('/domain/setcategory', 'domain/domain_set_category');
     Route::get('/domain/add', 'domain/domain_add');
+    Route::get('/domain/category', 'domain/category');
     Route::get('/domain', 'domain/domain');
 
     Route::post('/record/data/:id', 'domain/record_data');

--- a/route/app.php
+++ b/route/app.php
@@ -86,6 +86,7 @@ Route::group(function () {
     Route::post('/domain/data', 'domain/domain_data');
     Route::post('/domain/op', 'domain/domain_op');
     Route::post('/domain/list', 'domain/domain_list');
+    Route::any('/domain/dnscheck', 'domain/dnscheck');
     Route::get('/domain/add', 'domain/domain_add');
     Route::get('/domain', 'domain/domain');
 
@@ -95,6 +96,7 @@ Route::group(function () {
     Route::post('/record/delete/:id', 'domain/record_delete');
     Route::post('/record/status/:id', 'domain/record_status');
     Route::post('/record/remark/:id', 'domain/record_remark');
+    Route::post('/record/check/:id', 'domain/record_check');
     Route::post('/record/batch/:id', 'domain/record_batch');
     Route::post('/record/batchedit/:id', 'domain/record_batch_edit');
     Route::any('/record/batchadd/:id', 'domain/record_batch_add');


### PR DESCRIPTION
添加DNS检测工具页面和相关功能，包括：
1. 在导航菜单添加DNS检测工具入口
2. 实现DNS记录检测功能，支持多种记录类型
3. 提供多种DNS服务器选择进行检测
4. 在记录管理页面添加单条记录检测按钮
5. 实现检测结果可视化展示
<img width="2566" height="742" alt="bd7addadce529ea66ff7ccfe34834d66" src="https://github.com/user-attachments/assets/17e1930a-3403-473b-96cc-3299d67a8b25" />
