### PR TITLE
feat(db): 支持 PostgreSQL 作为后端数据库

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -4,7 +4,8 @@ APP_DEBUG = false
 DEFAULT_TIMEZONE = Asia/Shanghai
 
 [DATABASE]
-TYPE = mysql
+DRIVER = {dbdriver}
+TYPE = {dbtype}
 HOSTNAME = {dbhost}
 DATABASE = {dbname}
 USERNAME = {dbuser}

--- a/app/AppService.php
+++ b/app/AppService.php
@@ -17,6 +17,6 @@ class AppService extends Service
 
     public function boot()
     {
-        // 服务启动
+        error_reporting(error_reporting() & ~E_DEPRECATED & ~E_USER_DEPRECATED);
     }
 }

--- a/app/AppService.php
+++ b/app/AppService.php
@@ -17,6 +17,6 @@ class AppService extends Service
 
     public function boot()
     {
-        error_reporting(error_reporting() & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+        // 服务启动
     }
 }

--- a/app/common.php
+++ b/app/common.php
@@ -258,7 +258,12 @@ function config_get($key, $default = null, $force = false)
 
 function config_set($key, $value)
 {
-    $res = Db::name('config')->replace()->insert(['key' => $key, 'value' => $value]);
+    $exists = Db::name('config')->where('key', $key)->find();
+    if ($exists) {
+        $res = Db::name('config')->where('key', $key)->update(['value' => $value]);
+    } else {
+        $res = Db::name('config')->insert(['key' => $key, 'value' => $value]);
+    }
     return $res !== false;
 }
 
@@ -611,6 +616,10 @@ function getDomainDate($domain)
 function checkTableExists($table)
 {
     $prefix = env('database.prefix', 'dnsmgr_');
-    $res = Db::query("SHOW TABLES LIKE '" . $prefix . $table . "'");
-    return !empty($res);
+    try {
+        $tables = Db::getConnection()->getTables();
+    } catch (\Exception $e) {
+        return false;
+    }
+    return in_array($prefix . $table, $tables, true);
 }

--- a/app/controller/Cert.php
+++ b/app/controller/Cert.php
@@ -217,32 +217,32 @@ class Cert extends BaseController
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
 
-        $select = Db::name('cert_order')->alias('A')->leftJoin('cert_account B', 'A.aid = B.id');
+        $select = Db::name('cert_order')->alias('a')->leftJoin('cert_account b', 'a.aid = b.id');
         if (!empty($id)) {
-            $select->where('A.id', $id);
+            $select->where('a.id', $id);
         } elseif (!empty($domain)) {
             $oids = Db::name('cert_domain')->where('domain', 'like', '%' . $domain . '%')->column('oid');
-            $select->whereIn('A.id', $oids);
+            $select->whereIn('a.id', $oids);
         }
         if (!empty($aid)) {
-            $select->where('A.aid', $aid);
+            $select->where('a.aid', $aid);
         }
         if (!empty($type)) {
-            $select->where('B.type', $type);
+            $select->where('b.type', $type);
         }
         if (!isNullOrEmpty($status)) {
             if ($status == '5') {
-                $select->where('A.status', '<', 0);
+                $select->where('a.status', '<', 0);
             } elseif ($status == '6') {
-                $select->where('A.expiretime', '<', date('Y-m-d H:i:s', time() + 86400 * 7))->where('A.expiretime', '>=', date('Y-m-d H:i:s'));
+                $select->where('a.expiretime', '<', date('Y-m-d H:i:s', time() + 86400 * 7))->where('a.expiretime', '>=', date('Y-m-d H:i:s'));
             } elseif ($status == '7') {
-                $select->where('A.expiretime', '<', date('Y-m-d H:i:s'));
+                $select->where('a.expiretime', '<', date('Y-m-d H:i:s'));
             } else {
-                $select->where('A.status', $status);
+                $select->where('a.status', $status);
             }
         }
         $total = $select->count();
-        $rows = $select->fieldRaw('A.*,B.type,B.remark aremark')->order('id', 'desc')->limit($offset, $limit)->select();
+        $rows = $select->fieldRaw('a.*,b.type,b.remark aremark')->order('id', 'desc')->limit($offset, $limit)->select();
 
         $list = [];
         foreach ($rows as $row) {
@@ -505,7 +505,7 @@ class Cert extends BaseController
             $mainDomain = getMainDomain($domain);
             $drow = Db::name('domain')->where('name', $mainDomain)->find();
             if (!$drow) {
-                $drow = Db::name('domain_alias')->alias('A')->join('domain B', 'A.did = B.id')->where('A.name', $mainDomain)->find();
+                $drow = Db::name('domain_alias')->alias('a')->join('domain b', 'a.did = b.id')->where('a.name', $mainDomain)->find();
                 if (!$drow) {
                     if (substr($domain, 0, 2) == '*.') $domain = substr($domain, 2);
                     if (!$cname || !Db::name('cert_cname')->where('domain', $domain)->where('status', 1)->find()) {
@@ -651,27 +651,27 @@ class Cert extends BaseController
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
 
-        $select = Db::name('cert_deploy')->alias('A')->leftJoin('cert_account B', 'A.aid = B.id')->leftJoin('cert_order C', 'A.oid = C.id')->leftJoin('cert_account D', 'C.aid = D.id');
+        $select = Db::name('cert_deploy')->alias('a')->leftJoin('cert_account b', 'a.aid = b.id')->leftJoin('cert_order c', 'a.oid = c.id')->leftJoin('cert_account d', 'c.aid = d.id');
         if (!empty($oid)) {
-            $select->where('A.oid', $oid);
+            $select->where('a.oid', $oid);
         } elseif (!empty($domain)) {
             $oids = Db::name('cert_domain')->where('domain', 'like', '%' . $domain . '%')->column('oid');
             $select->whereIn('oid', $oids);
         }
         if (!empty($aid)) {
-            $select->where('A.aid', $aid);
+            $select->where('a.aid', $aid);
         }
         if (!empty($type)) {
-            $select->where('B.type', $type);
+            $select->where('b.type', $type);
         }
         if (!isNullOrEmpty($status)) {
-            $select->where('A.status', $status);
+            $select->where('a.status', $status);
         }
         if (!empty($remark)) {
-            $select->where('A.remark', $remark);
+            $select->where('a.remark', $remark);
         }
         $total = $select->count();
-        $rows = $select->fieldRaw('A.*,B.type,B.remark aremark,B.name aname,D.type certtype,D.id certaid')->order('id', 'desc')->limit($offset, $limit)->select();
+        $rows = $select->fieldRaw('a.*,b.type,b.remark aremark,b.name aname,d.type certtype,d.id certaid')->order('id', 'desc')->limit($offset, $limit)->select();
 
         $list = [];
         foreach ($rows as $row) {
@@ -812,7 +812,7 @@ class Cert extends BaseController
         $task = null;
         if ($action == 'edit') {
             $id = input('get.id/d');
-            $task = Db::name('cert_deploy')->alias('A')->join('cert_account B', 'A.aid = B.id')->where('A.id', $id)->fieldRaw('A.id,A.aid,A.oid,A.config,A.remark,B.type')->find();
+            $task = Db::name('cert_deploy')->alias('a')->join('cert_account b', 'a.aid = b.id')->where('a.id', $id)->fieldRaw('a.id,a.aid,a.oid,a.config,a.remark,b.type')->find();
             if (empty($task)) return $this->alert('error', '自动部署任务不存在');
         }
 
@@ -827,7 +827,7 @@ class Cert extends BaseController
         View::assign('accounts', $accounts);
 
         $orders = [];
-        foreach (Db::name('cert_order')->alias('A')->leftJoin('cert_account B', 'A.aid = B.id')->where('status', '<>', 4)->fieldRaw('A.id,A.aid,B.type,B.remark aremark')->order('id', 'desc')->select() as $row) {
+        foreach (Db::name('cert_order')->alias('a')->leftJoin('cert_account b', 'a.aid = b.id')->where('status', '<>', 4)->fieldRaw('a.id,a.aid,b.type,b.remark aremark')->order('id', 'desc')->select() as $row) {
             $domains = Db::name('cert_domain')->where('oid', $row['id'])->order('sort', 'ASC')->column('domain');
             $domainstr = count($domains) > 2 ? implode('、', array_slice($domains, 0, 2)) . '等' . count($domains) . '个域名' : implode('、', $domains);
             if ($row['aid'] == 0) {
@@ -863,12 +863,12 @@ class Cert extends BaseController
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
 
-        $select = Db::name('cert_cname')->alias('A')->leftJoin('domain B', 'A.did = B.id');
+        $select = Db::name('cert_cname')->alias('a')->leftJoin('domain b', 'a.did = b.id');
         if (!empty($kw)) {
-            $select->whereLike('A.domain', '%' . $kw . '%');
+            $select->whereLike('a.domain', '%' . $kw . '%');
         }
         $total = $select->count();
-        $rows = $select->order('A.id', 'desc')->limit($offset, $limit)->field('A.*,B.name cnamedomain')->select();
+        $rows = $select->order('a.id', 'desc')->limit($offset, $limit)->field('a.*,b.name cnamedomain')->select();
 
         $list = [];
         foreach ($rows as $row) {
@@ -937,7 +937,7 @@ class Cert extends BaseController
             return json(['code' => 0]);
         } elseif ($action == 'check') {
             $id = input('post.id/d');
-            $row = Db::name('cert_cname')->alias('A')->join('domain B', 'A.did = B.id')->where('A.id', $id)->field('A.*,B.name cnamedomain')->find();
+            $row = Db::name('cert_cname')->alias('a')->join('domain b', 'a.did = b.id')->where('a.id', $id)->field('a.*,b.name cnamedomain')->find();
             if (!$row) return json(['code' => -1, 'msg' => '自动部署任务不存在']);
 
             $status = 1;

--- a/app/controller/Cloudflare.php
+++ b/app/controller/Cloudflare.php
@@ -387,10 +387,10 @@ class Cloudflare extends BaseController
             }
 
             // 查询域名信息
-            $domainRow = Db::name('domain')->alias('A')
-                ->join('account B', 'A.aid = B.id')
-                ->where('A.id', $domainId)
-                ->field('A.*, B.type, B.config account_config')
+            $domainRow = Db::name('domain')->alias('a')
+                ->join('account b', 'a.aid = b.id')
+                ->where('a.id', $domainId)
+                ->field('a.*, b.type, b.config account_config')
                 ->find();
 
             if (!$domainRow) {
@@ -815,10 +815,10 @@ class Cloudflare extends BaseController
         if (!checkPermission(2)) {
             throw new Exception('无权限');
         }
-        $row = Db::name('domain')->alias('A')
-            ->join('account B', 'A.aid = B.id')
-            ->where('A.id', $domainId)
-            ->field('A.*,B.type,B.config account_config,B.name account_name,B.remark account_remark')
+        $row = Db::name('domain')->alias('a')
+            ->join('account b', 'a.aid = b.id')
+            ->where('a.id', $domainId)
+            ->field('a.*,b.type,b.config account_config,b.name account_name,b.remark account_remark')
             ->find();
         if (!$row) {
             throw new Exception('域名不存在');
@@ -1089,9 +1089,9 @@ class Cloudflare extends BaseController
 
     private function findTxtRecordTargetDomains(array $currentDomain, string $hostname): array
     {
-        $rows = Db::name('domain')->alias('D')
-            ->join('account A', 'D.aid = A.id')
-            ->field('D.id,D.aid,D.name,A.type account_type,A.name account_name,A.remark account_remark')
+        $rows = Db::name('domain')->alias('d')
+            ->join('account a', 'd.aid = a.id')
+            ->field('d.id,d.aid,d.name,a.type account_type,a.name account_name,a.remark account_remark')
             ->select()
             ->toArray();
 

--- a/app/controller/Dmonitor.php
+++ b/app/controller/Dmonitor.php
@@ -44,10 +44,10 @@ class Dmonitor extends BaseController
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
 
-        $select = Db::name('dmtask')->alias('A')->join('domain B', 'A.did = B.id');
+        $select = Db::name('dmtask')->alias('a')->join('domain b', 'a.did = b.id');
         if (!empty($kw)) {
             if ($type == 1) {
-                $select->whereLike('rr|B.name', '%' . $kw . '%');
+                $select->whereLike('rr|b.name', '%' . $kw . '%');
             } elseif ($type == 2) {
                 $select->where('recordid', $kw);
             } elseif ($type == 3) {
@@ -62,7 +62,7 @@ class Dmonitor extends BaseController
             $select->where('status', intval($status));
         }
         $total = $select->count();
-        $list = $select->order('A.id', 'desc')->limit($offset, $limit)->field('A.*,B.name domain')->select()->toArray();
+        $list = $select->order('a.id', 'desc')->limit($offset, $limit)->field('a.*,b.name domain')->select()->toArray();
 
         foreach ($list as &$row) {
             $row['addtimestr'] = date('Y-m-d H:i:s', $row['addtime']);
@@ -192,7 +192,7 @@ class Dmonitor extends BaseController
         }
 
         $domains = [];
-        $domainList = Db::name('domain')->alias('A')->join('account B', 'A.aid = B.id')->field('A.id,A.name,B.type')->select();
+        $domainList = Db::name('domain')->alias('a')->join('account b', 'a.aid = b.id')->field('a.id,a.name,b.type')->select();
         foreach ($domainList as $row) {
             $domains[] = ['id'=>$row['id'], 'name'=>$row['name'], 'type'=>$row['type']];
         }
@@ -251,8 +251,16 @@ class Dmonitor extends BaseController
         if ($this->request->isPost()) {
             $days = input('post.days/d');
             if (!$days || $days < 0) return json(['code' => -1, 'msg' => '参数错误']);
-            Db::execute("DELETE FROM `" . config('database.connections.mysql.prefix') . "dmlog` WHERE `date`<'" . date("Y-m-d H:i:s", strtotime("-" . $days . " days")) . "'");
-            Db::execute("OPTIMIZE TABLE `" . config('database.connections.mysql.prefix') . "dmlog`");
+            $driver = config('database.default');
+            $prefix = config('database.connections.' . $driver . '.prefix');
+            $cutoff = date('Y-m-d H:i:s', strtotime('-' . $days . ' days'));
+            if ($driver === 'pgsql') {
+                Db::execute("DELETE FROM " . $prefix . "dmlog WHERE date < '" . $cutoff . "'");
+                Db::execute("VACUUM " . $prefix . "dmlog");
+            } else {
+                Db::execute("DELETE FROM `" . $prefix . "dmlog` WHERE `date`<'" . $cutoff . "'");
+                Db::execute("OPTIMIZE TABLE `" . $prefix . "dmlog`");
+            }
             return json(['code' => 0, 'msg' => '清理成功']);
         }
     }

--- a/app/controller/Domain.php
+++ b/app/controller/Domain.php
@@ -194,46 +194,46 @@ class Domain extends BaseController
         $id = input('post.id');
         $aid = input('post.aid', null, 'trim');
 
-        $select = Db::name('domain')->alias('A')->join('account B', 'A.aid = B.id');
+        $select = Db::name('domain')->alias('a')->join('account b', 'a.aid = b.id');
         if (!empty($id)) {
-            $select->where('A.id', $id);
+            $select->where('a.id', $id);
         } elseif (!empty($kw)) {
-            $select->whereLike('A.name|A.remark', '%' . $kw . '%');
+            $select->whereLike('a.name|a.remark', '%' . $kw . '%');
         }
         if (!empty($aid)) {
-            $select->where('A.aid', $aid);
+            $select->where('a.aid', $aid);
         }
         if (!empty($type)) {
-            $select->whereLike('B.type', $type);
+            $select->whereLike('b.type', $type);
         }
         if (request()->user['level'] == 1) {
-            $select->where('is_hide', 0)->where('A.name', 'in', request()->user['permission']);
+            $select->where('is_hide', 0)->where('a.name', 'in', request()->user['permission']);
         }
         if (!isNullOrEmpty($status)) {
             if ($status == '2') {
-                $select->where('A.expiretime', '<=', date('Y-m-d H:i:s'));
+                $select->where('a.expiretime', '<=', date('Y-m-d H:i:s'));
             } elseif ($status == '1') {
-                $select->where('A.expiretime', '<=', date('Y-m-d H:i:s', time() + 86400 * 30))->where('A.expiretime', '>', date('Y-m-d H:i:s'));
+                $select->where('a.expiretime', '<=', date('Y-m-d H:i:s', time() + 86400 * 30))->where('a.expiretime', '>', date('Y-m-d H:i:s'));
             }
         }
         $total = $select->count();
         switch ($order) {
             case '1':
-                $select->order('A.regtime', 'asc');
+                $select->order('a.regtime', 'asc');
                 break;
             case '2':
-                $select->order('A.regtime', 'desc');
+                $select->order('a.regtime', 'desc');
                 break;
             case '3':
-                $select->order('A.expiretime', 'asc');
+                $select->order('a.expiretime', 'asc');
                 break;
             case '4':
-                $select->order('A.expiretime', 'desc');
+                $select->order('a.expiretime', 'desc');
                 break;
             default:
-                $select->order('A.id', 'desc');
+                $select->order('a.id', 'desc');
         }
-        $rows = $select->fieldRaw('A.*,B.type,B.remark aremark')->limit($offset, $limit)->select();
+        $rows = $select->fieldRaw('a.*,b.type,b.remark aremark')->limit($offset, $limit)->select();
 
         $list = [];
         foreach ($rows as $row) {
@@ -1011,9 +1011,9 @@ class Domain extends BaseController
             return redirect('/record/' . request()->user['id']);
         }
 
-        $list = Db::name('domain')->alias('A')->join('account B', 'A.aid = B.id')
-            ->field('A.id, A.name, A.aid, B.type')
-            ->order('A.name', 'asc')
+        $list = Db::name('domain')->alias('a')->join('account b', 'a.aid = b.id')
+            ->field('a.id, a.name, a.aid, b.type')
+            ->order('a.name', 'asc')
             ->select();
 
         $domainList = [];

--- a/app/controller/Index.php
+++ b/app/controller/Index.php
@@ -56,12 +56,11 @@ class Index extends BaseController
             $this->db_update();
         }
 
-        $tmp = 'version()';
-        $mysqlVersion = Db::query("select version()")[0][$tmp];
+        $dbVersion = Db::query("select version() as v")[0]['v'] ?? '';
         $info = [
             'framework_version' => app()->version(),
             'php_version' => PHP_VERSION,
-            'mysql_version' => $mysqlVersion,
+            'mysql_version' => $dbVersion,
             'software' => $_SERVER['SERVER_SOFTWARE'] ?? '未知',
             'os' => php_uname(),
             'date' => date("Y-m-d H:i:s"),
@@ -73,13 +72,15 @@ class Index extends BaseController
 
     private function db_update()
     {
-        $sqls = file_get_contents(app()->getAppPath() . 'sql/update.sql');
-        $mysql_prefix = env('database.prefix', 'dnsmgr_');
+        $driver = env('database.driver', 'mysql');
+        $file = $driver === 'pgsql' ? 'sql/update.pgsql.sql' : 'sql/update.sql';
+        $sqls = file_get_contents(app()->getAppPath() . $file);
+        $db_prefix = env('database.prefix', 'dnsmgr_');
         $sqls = explode(';', $sqls);
         foreach ($sqls as $value) {
             $value = trim($value);
             if (empty($value)) continue;
-            $value = str_replace('dnsmgr_', $mysql_prefix, $value);
+            $value = str_replace('dnsmgr_', $db_prefix, $value);
             try {
                 Db::execute($value);
             } catch (Exception $e) {

--- a/app/controller/Install.php
+++ b/app/controller/Install.php
@@ -31,27 +31,25 @@ class Install extends BaseController
                     return json(['code' => 0, 'msg' => '必填项不能为空']);
                 }
 
-                $sqls = file_get_contents(app()->getAppPath() . 'sql/install.sql');
-                $sqls = explode(';', $sqls);
-                $mysql_prefix = env('database.prefix', 'dnsmgr_');
-
-                $password = password_hash($admin_password, PASSWORD_DEFAULT);
-                $sqls[] = "REPLACE INTO `" . $mysql_prefix . "config` VALUES ('sys_key', '" . random(16) . "')";
-                $sqls[] = "INSERT INTO `" . $mysql_prefix . "user` (`username`,`password`,`level`,`regtime`,`lasttime`,`status`) VALUES ('" . addslashes($admin_username) . "', '$password', 2, NOW(), NOW(), 1)";
+                $driver = env('database.driver', 'mysql');
+                $prefix = env('database.prefix', 'dnsmgr_');
+                $sqls = $this->loadInstallSqls($driver);
+                $sqls = array_merge($sqls, $this->buildSeedSqls($driver, $prefix, $admin_username, $admin_password));
 
                 $success = 0;
-                $error = 0;
                 $errorMsg = null;
                 foreach ($sqls as $value) {
                     $value = trim($value);
                     if (empty($value)) continue;
-                    $value = str_replace('dnsmgr_', $mysql_prefix, $value);
-                    if (Db::execute($value) === false) {
-                        $error++;
-                        $dberror = Db::getErrorInfo();
-                        $errorMsg .= $dberror . "\n";
-                    } else {
-                        $success++;
+                    $value = str_replace('dnsmgr_', $prefix, $value);
+                    try {
+                        if (Db::execute($value) === false) {
+                            $errorMsg .= Db::getLastSql() . "\n";
+                        } else {
+                            $success++;
+                        }
+                    } catch (Exception $e) {
+                        $errorMsg .= $e->getMessage() . "\n";
                     }
                 }
                 if (empty($errorMsg)) {
@@ -61,30 +59,43 @@ class Install extends BaseController
                     return json(['code' => 0, 'msg' => $errorMsg]);
                 }
             } else {
-                $mysql_host = input('post.mysql_host', null, 'trim');
-                $mysql_port = intval(input('post.mysql_port', '3306'));
-                $mysql_user = input('post.mysql_user', null, 'trim');
-                $mysql_pwd = input('post.mysql_pwd', null, 'trim');
-                $mysql_name = input('post.mysql_name', null, 'trim');
-                $mysql_prefix = input('post.mysql_prefix', 'cloud_', 'trim');
+                $db_type = input('post.db_type', 'mysql', 'trim');
+                if (!in_array($db_type, ['mysql', 'pgsql'], true)) {
+                    return json(['code' => 0, 'msg' => '不支持的数据库类型']);
+                }
+                $db_host = input('post.mysql_host', null, 'trim');
+                $db_port = intval(input('post.mysql_port', $db_type === 'pgsql' ? '5432' : '3306'));
+                $db_user = input('post.mysql_user', null, 'trim');
+                $db_pwd = input('post.mysql_pwd', null, 'trim');
+                $db_name = input('post.mysql_name', null, 'trim');
+                $db_prefix = input('post.mysql_prefix', 'dnsmgr_', 'trim');
                 $admin_username = input('post.admin_username', null, 'trim');
                 $admin_password = input('post.admin_password', null, 'trim');
 
-                if (!$mysql_host || !$mysql_user || !$mysql_pwd || !$mysql_name || !$admin_username || !$admin_password) {
+                if (!$db_host || !$db_user || !$db_pwd || !$db_name || !$admin_username || !$admin_password) {
                     return json(['code' => 0, 'msg' => '必填项不能为空']);
                 }
 
                 $configData = file_get_contents(app()->getRootPath() . '.example.env');
-                $configData = str_replace(['{dbhost}', '{dbname}', '{dbuser}', '{dbpwd}', '{dbport}', '{dbprefix}'], [$mysql_host, $mysql_name, $mysql_user, $mysql_pwd, $mysql_port, $mysql_prefix], $configData);
+                $configData = str_replace(
+                    ['{dbdriver}', '{dbtype}', '{dbhost}', '{dbname}', '{dbuser}', '{dbpwd}', '{dbport}', '{dbprefix}'],
+                    [$db_type, $db_type, $db_host, $db_name, $db_user, $db_pwd, $db_port, $db_prefix],
+                    $configData
+                );
 
                 try {
-                    $DB = new PDO("mysql:host=" . $mysql_host . ";dbname=" . $mysql_name . ";port=" . $mysql_port, $mysql_user, $mysql_pwd);
+                    if ($db_type === 'pgsql') {
+                        $dsn = "pgsql:host={$db_host};port={$db_port};dbname={$db_name}";
+                    } else {
+                        $dsn = "mysql:host={$db_host};port={$db_port};dbname={$db_name}";
+                    }
+                    $DB = new PDO($dsn, $db_user, $db_pwd);
                 } catch (Exception $e) {
                     if ($e->getCode() == 2002) {
                         $errorMsg = '连接数据库失败：数据库地址填写错误！';
-                    } elseif ($e->getCode() == 1045) {
+                    } elseif ($e->getCode() == 1045 || $e->getCode() == '28P01' || $e->getCode() == '28000') {
                         $errorMsg = '连接数据库失败：数据库用户名或密码填写错误！';
-                    } elseif ($e->getCode() == 1049) {
+                    } elseif ($e->getCode() == 1049 || $e->getCode() == '3D000') {
                         $errorMsg = '连接数据库失败：数据库名不存在！';
                     } else {
                         $errorMsg = '连接数据库失败：' . $e->getMessage();
@@ -92,25 +103,23 @@ class Install extends BaseController
                     return json(['code' => 0, 'msg' => $errorMsg]);
                 }
                 $DB->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
-                $DB->exec("set sql_mode = ''");
-                $DB->exec("set names utf8");
+                if ($db_type === 'mysql') {
+                    $DB->exec("set sql_mode = ''");
+                    $DB->exec("set names utf8");
+                } else {
+                    $DB->exec("set client_encoding to 'UTF8'");
+                }
 
-                $sqls = file_get_contents(app()->getAppPath() . 'sql/install.sql');
-                $sqls = explode(';', $sqls);
-
-                $password = password_hash($admin_password, PASSWORD_DEFAULT);
-                $sqls[] = "REPLACE INTO `" . $mysql_prefix . "config` VALUES ('sys_key', '" . random(16) . "')";
-                $sqls[] = "INSERT INTO `" . $mysql_prefix . "user` (`username`,`password`,`level`,`regtime`,`lasttime`,`status`) VALUES ('" . addslashes($admin_username) . "', '$password', 2, NOW(), NOW(), 1)";
+                $sqls = $this->loadInstallSqls($db_type);
+                $sqls = array_merge($sqls, $this->buildSeedSqls($db_type, $db_prefix, $admin_username, $admin_password));
 
                 $success = 0;
-                $error = 0;
                 $errorMsg = null;
                 foreach ($sqls as $value) {
                     $value = trim($value);
                     if (empty($value)) continue;
-                    $value = str_replace('dnsmgr_', $mysql_prefix, $value);
+                    $value = str_replace('dnsmgr_', $db_prefix, $value);
                     if ($DB->exec($value) === false) {
-                        $error++;
                         $dberror = $DB->errorInfo();
                         $errorMsg .= $dberror[2] . "\n";
                     } else {
@@ -130,5 +139,30 @@ class Install extends BaseController
         }
         View::assign('dbconfig', $dbconfig);
         return view();
+    }
+
+    private function loadInstallSqls(string $driver): array
+    {
+        $file = $driver === 'pgsql' ? 'sql/install.pgsql.sql' : 'sql/install.sql';
+        $content = file_get_contents(app()->getAppPath() . $file);
+        return explode(';', $content);
+    }
+
+    private function buildSeedSqls(string $driver, string $prefix, string $admin_username, string $admin_password): array
+    {
+        $password = password_hash($admin_password, PASSWORD_DEFAULT);
+        $sysKey = random(16);
+        $userName = addslashes($admin_username);
+
+        if ($driver === 'pgsql') {
+            return [
+                "INSERT INTO {$prefix}config (\"key\", value) VALUES ('sys_key', '{$sysKey}') ON CONFLICT (\"key\") DO UPDATE SET value = EXCLUDED.value",
+                "INSERT INTO {$prefix}user (username, password, level, regtime, lasttime, status) VALUES ('{$userName}', '{$password}', 2, NOW(), NOW(), 1)",
+            ];
+        }
+        return [
+            "REPLACE INTO `{$prefix}config` VALUES ('sys_key', '{$sysKey}')",
+            "INSERT INTO `{$prefix}user` (`username`,`password`,`level`,`regtime`,`lasttime`,`status`) VALUES ('{$userName}', '{$password}', 2, NOW(), NOW(), 1)",
+        ];
     }
 }

--- a/app/controller/Optimizeip.php
+++ b/app/controller/Optimizeip.php
@@ -46,10 +46,10 @@ class Optimizeip extends BaseController
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
 
-        $select = Db::name('optimizeip')->alias('A')->join('domain B', 'A.did = B.id');
+        $select = Db::name('optimizeip')->alias('a')->join('domain b', 'a.did = b.id');
         if (!empty($kw)) {
             if ($type == 1) {
-                $select->whereLike('rr|B.name', '%' . $kw . '%');
+                $select->whereLike('rr|b.name', '%' . $kw . '%');
             } elseif ($type == 2) {
                 $select->whereLike('remark', '%' . $kw . '%');
             }
@@ -58,7 +58,7 @@ class Optimizeip extends BaseController
             $select->where('status', intval($status));
         }
         $total = $select->count();
-        $list = $select->order('A.id', 'desc')->limit($offset, $limit)->field('A.*,B.name domain')->select();
+        $list = $select->order('a.id', 'desc')->limit($offset, $limit)->field('a.*,b.name domain')->select();
 
         return json(['total' => $total, 'rows' => $list]);
     }
@@ -156,7 +156,7 @@ class Optimizeip extends BaseController
         }
 
         $domains = [];
-        foreach (Db::name('domain')->alias('A')->join('account B', 'A.aid = B.id')->field('A.*')->where('B.type', '<>', 'cloudflare')->select() as $row) {
+        foreach (Db::name('domain')->alias('a')->join('account b', 'a.aid = b.id')->field('a.*')->where('b.type', '<>', 'cloudflare')->select() as $row) {
             $domains[$row['id']] = $row['name'];
         }
         View::assign('domains', $domains);

--- a/app/controller/Schedule.php
+++ b/app/controller/Schedule.php
@@ -25,10 +25,10 @@ class Schedule extends BaseController
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
 
-        $select = Db::name('sctask')->alias('A')->join('domain B', 'A.did = B.id');
+        $select = Db::name('sctask')->alias('a')->join('domain b', 'a.did = b.id');
         if (!empty($kw)) {
             if ($type == 1) {
-                $select->whereLike('rr|B.name', '%' . $kw . '%');
+                $select->whereLike('rr|b.name', '%' . $kw . '%');
             } elseif ($type == 2) {
                 $select->where('recordid', $kw);
             } elseif ($type == 3) {
@@ -41,7 +41,7 @@ class Schedule extends BaseController
             $select->where('type', $stype);
         }
         $total = $select->count();
-        $list = $select->order('A.id', 'desc')->limit($offset, $limit)->field('A.*,B.name domain')->select()->toArray();
+        $list = $select->order('a.id', 'desc')->limit($offset, $limit)->field('a.*,b.name domain')->select()->toArray();
 
         foreach ($list as &$row) {
             $row['addtimestr'] = date('Y-m-d H:i:s', $row['addtime']);
@@ -151,7 +151,7 @@ class Schedule extends BaseController
         }
 
         $domains = [];
-        $domainList = Db::name('domain')->alias('A')->join('account B', 'A.aid = B.id')->field('A.id,A.name,B.type')->select();
+        $domainList = Db::name('domain')->alias('a')->join('account b', 'a.aid = b.id')->field('a.id,a.name,b.type')->select();
         foreach ($domainList as $row) {
             $domains[] = ['id'=>$row['id'], 'name'=>$row['name'], 'type'=>$row['type']];
         }

--- a/app/db/builder/Pgsql.php
+++ b/app/db/builder/Pgsql.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+namespace app\db\builder;
+
+use think\db\builder\Pgsql as BasePgsql;
+use think\db\BaseQuery;
+
+/**
+ * PHP 的 pdo_pgsql 把所有 ? 默认按 text 发送，配合 think-orm 默认的
+ * `INSERT INTO t (cols) SELECT ?,? UNION ALL SELECT ?,?` 模板会让 PG
+ * 推断成 text 列，遇到 int/smallint 列即报 42804。改为多行 VALUES，
+ * PG 可由 INSERT 目标列直接推断参数类型。
+ */
+class Pgsql extends BasePgsql
+{
+    protected $insertAllSql = 'INSERT INTO %TABLE% (%FIELD%) VALUES %DATA% %COMMENT%';
+
+    /**
+     * 让 LIKE 行为与 MySQL 默认一致：PG 的 LIKE 区分大小写，
+     * 替换为 ILIKE 以恢复用户搜索时的预期行为。
+     */
+    protected function parseLike(BaseQuery $query, string $key, string $exp, $value, $field, int $bindType, ?string $logic = null): string
+    {
+        $exp = preg_replace('/\bLIKE\b/i', 'ILIKE', $exp);
+        return parent::parseLike($query, $key, $exp, $value, $field, $bindType, $logic);
+    }
+
+    public function insertAll(BaseQuery $query, array $dataSet): string
+    {
+        $options = $query->getOptions();
+        $bind = $query->getFieldsBindType();
+
+        if (empty($options['field']) || '*' == $options['field']) {
+            $allowFields = array_keys($bind);
+        } else {
+            $allowFields = $options['field'];
+        }
+
+        $values = [];
+        $insertFields = null;
+        foreach ($dataSet as $data) {
+            $data = $this->parseData($query, $data, $allowFields, $bind);
+            $values[] = '(' . implode(',', array_values($data)) . ')';
+            if ($insertFields === null) {
+                $insertFields = array_keys($data);
+            }
+        }
+
+        $fields = [];
+        foreach ((array) $insertFields as $field) {
+            $fields[] = $this->parseKey($query, $field);
+        }
+
+        return str_replace(
+            ['%INSERT%', '%TABLE%', '%EXTRA%', '%FIELD%', '%DATA%', '%COMMENT%'],
+            [
+                !empty($options['replace']) ? 'REPLACE' : 'INSERT',
+                $this->parseTable($query, $options['table']),
+                $this->parseExtra($query, $options['extra']),
+                implode(' , ', $fields),
+                implode(',', $values),
+                $this->parseComment($query, $options['comment']),
+            ],
+            $this->insertAllSql
+        );
+    }
+
+    public function insertAllByKeys(BaseQuery $query, array $keys, array $datas): string
+    {
+        $options = $query->getOptions();
+        $bind = $query->getFieldsBindType();
+
+        $fields = [];
+        foreach ($keys as $field) {
+            $fields[] = $this->parseKey($query, $field);
+        }
+
+        $values = [];
+        foreach ($datas as $data) {
+            foreach ($data as $idx => &$val) {
+                $col = $keys[$idx] ?? null;
+                if (!$query->isAutoBind()) {
+                    $val = ($col !== null && \think\db\Connection::PARAM_STR == ($bind[$col] ?? \think\db\Connection::PARAM_STR))
+                        ? '\'' . $val . '\''
+                        : $val;
+                } else {
+                    $val = $this->parseDataBind($query, $col ?? (string) $idx, $val, $bind);
+                }
+            }
+            unset($val);
+            $values[] = '(' . implode(',', $data) . ')';
+        }
+
+        return str_replace(
+            ['%INSERT%', '%TABLE%', '%EXTRA%', '%FIELD%', '%DATA%', '%COMMENT%'],
+            [
+                !empty($options['replace']) ? 'REPLACE' : 'INSERT',
+                $this->parseTable($query, $options['table']),
+                $this->parseExtra($query, $options['extra']),
+                implode(' , ', $fields),
+                implode(',', $values),
+                $this->parseComment($query, $options['comment']),
+            ],
+            $this->insertAllSql
+        );
+    }
+}

--- a/app/service/CertOrderService.php
+++ b/app/service/CertOrderService.php
@@ -74,7 +74,7 @@ class CertOrderService
                 $drow = Db::name('domain')->where('name', idn_to_utf8($mainDomain))->find();
             }
             if (!$drow) {
-                $drow = Db::name('domain_alias')->alias('A')->join('domain B', 'A.did = B.id')->where('A.name', $mainDomain)->field('A.name as alias,B.name as maindomain')->find();
+                $drow = Db::name('domain_alias')->alias('a')->join('domain b', 'a.did = b.id')->where('a.name', $mainDomain)->field('a.name as alias,b.name as maindomain')->find();
                 if ($drow) {
                     $this->domainsAliasList[$drow['alias']] = $drow['maindomain'];
                 }
@@ -428,7 +428,7 @@ class CertOrderService
     //检查域名CNAME代理记录
     private function checkDomainCname($id)
     {
-        $row = Db::name('cert_cname')->alias('A')->join('domain B', 'A.did = B.id')->where('A.id', $id)->field('A.*,B.name cnamedomain')->find();
+        $row = Db::name('cert_cname')->alias('a')->join('domain b', 'a.did = b.id')->where('a.id', $id)->field('a.*,b.name cnamedomain')->find();
         $domain = '_acme-challenge.' . $row['domain'];
         $record = $row['rr'] . '.' . $row['cnamedomain'];
         $result = \app\utils\DnsQueryUtils::get_dns_records($domain, 'CNAME');

--- a/app/service/ExpireNoticeService.php
+++ b/app/service/ExpireNoticeService.php
@@ -66,7 +66,15 @@ class ExpireNoticeService
 
     private function refreshExpiringDomainList($max_day)
     {
-        $domainList = Db::name('domain')->field('id,name')->whereRaw('expiretime>=(NOW() - INTERVAL 5 DAY) AND expiretime<=(NOW() + INTERVAL ' . $max_day . ' DAY) AND checktime<=(NOW() - INTERVAL 1 DAY)')->select();
+        $now = time();
+        $minExpire = date('Y-m-d H:i:s', $now - 5 * 86400);
+        $maxExpire = date('Y-m-d H:i:s', $now + $max_day * 86400);
+        $maxCheck = date('Y-m-d H:i:s', $now - 86400);
+        $domainList = Db::name('domain')->field('id,name')
+            ->where('expiretime', '>=', $minExpire)
+            ->where('expiretime', '<=', $maxExpire)
+            ->where('checktime', '<=', $maxCheck)
+            ->select();
         $count = 0;
         foreach ($domainList as $domain) {
             $res = $this->updateDomainDate($domain['id'], $domain['name']);
@@ -84,7 +92,19 @@ class ExpireNoticeService
 
     private function noticeExpiringDomainList($max_day, $days)
     {
-        $domainList = Db::name('domain')->field('id,name,expiretime')->whereRaw('expiretime>=NOW() AND expiretime<=(NOW() + INTERVAL ' . $max_day . ' DAY) AND is_notice=1 AND (noticetime IS NULL OR noticetime<=(NOW() - INTERVAL 20 HOUR))')->order('expiretime', 'asc')->select();
+        $now = time();
+        $nowDate = date('Y-m-d H:i:s', $now);
+        $maxExpire = date('Y-m-d H:i:s', $now + $max_day * 86400);
+        $maxNotice = date('Y-m-d H:i:s', $now - 20 * 3600);
+        $domainList = Db::name('domain')->field('id,name,expiretime')
+            ->where('expiretime', '>=', $nowDate)
+            ->where('expiretime', '<=', $maxExpire)
+            ->where('is_notice', 1)
+            ->where(function ($q) use ($maxNotice) {
+                $q->whereNull('noticetime')->whereOr('noticetime', '<=', $maxNotice);
+            })
+            ->order('expiretime', 'asc')
+            ->select();
         $noticeList = [];
         foreach ($domainList as $domain) {
             $expireDay = intval((strtotime($domain['expiretime']) - time()) / 86400);

--- a/app/service/OptimizeService.php
+++ b/app/service/OptimizeService.php
@@ -189,7 +189,7 @@ class OptimizeService
                 continue;
             }
 
-            $drow = Db::name('domain')->alias('A')->join('account B', 'A.aid = B.id')->where('A.id', $row['did'])->field('A.*,B.type')->find();
+            $drow = Db::name('domain')->alias('a')->join('account b', 'a.aid = b.id')->where('a.id', $row['did'])->field('a.*,b.type')->find();
             if (!$drow) {
                 throw new Exception('域名不存在（ID：'.$row['did'].'）');
             }

--- a/app/service/ScheduleService.php
+++ b/app/service/ScheduleService.php
@@ -33,7 +33,7 @@ class ScheduleService
 
     public function execute_one($row)
     {
-        $drow = Db::name('domain')->alias('A')->join('account B', 'A.aid = B.id')->where('A.id', $row['did'])->field('A.*,B.type,B.config')->find();
+        $drow = Db::name('domain')->alias('a')->join('account b', 'a.aid = b.id')->where('a.id', $row['did'])->field('a.*,b.type,b.config')->find();
         if (!$drow) throw new Exception('域名不存在');
 
         Db::name('sctask')->where('id', $row['id'])->update(['updatetime' => time()]);

--- a/app/service/TaskRunner.php
+++ b/app/service/TaskRunner.php
@@ -71,7 +71,7 @@ class TaskRunner
         }
 
         if ($action > 0) {
-            $drow = $this->db()->name('domain')->alias('A')->join('account B', 'A.aid = B.id')->where('A.id', $row['did'])->field('A.*,B.type,B.config')->find();
+            $drow = $this->db()->name('domain')->alias('a')->join('account b', 'a.aid = b.id')->where('a.id', $row['did'])->field('a.*,b.type,b.config')->find();
             if (!$drow) {
                 echo '域名不存在（ID：'.$row['did'].'）'."\n";
                 $this->closeDb();

--- a/app/sql/install.pgsql.sql
+++ b/app/sql/install.pgsql.sql
@@ -1,0 +1,252 @@
+DROP TABLE IF EXISTS dnsmgr_config;
+CREATE TABLE dnsmgr_config (
+  "key" varchar(32) NOT NULL,
+  value text DEFAULT NULL,
+  PRIMARY KEY ("key")
+);
+
+INSERT INTO dnsmgr_config ("key", value) VALUES ('version', '1048');
+INSERT INTO dnsmgr_config ("key", value) VALUES ('notice_mail', '0');
+INSERT INTO dnsmgr_config ("key", value) VALUES ('notice_wxtpl', '0');
+INSERT INTO dnsmgr_config ("key", value) VALUES ('mail_smtp', 'smtp.qq.com');
+INSERT INTO dnsmgr_config ("key", value) VALUES ('mail_port', '465');
+
+DROP TABLE IF EXISTS dnsmgr_account;
+CREATE TABLE dnsmgr_account (
+  id serial PRIMARY KEY,
+  type varchar(20) NOT NULL,
+  name varchar(255) NOT NULL,
+  config text DEFAULT NULL,
+  remark varchar(100) DEFAULT NULL,
+  addtime timestamp DEFAULT NULL
+);
+
+DROP TABLE IF EXISTS dnsmgr_domain;
+CREATE TABLE dnsmgr_domain (
+  id serial PRIMARY KEY,
+  aid integer NOT NULL,
+  name varchar(255) NOT NULL,
+  thirdid varchar(60) DEFAULT NULL,
+  addtime timestamp DEFAULT NULL,
+  is_hide smallint NOT NULL DEFAULT 0,
+  is_sso smallint NOT NULL DEFAULT 0,
+  recordcount integer NOT NULL DEFAULT 0,
+  remark varchar(100) DEFAULT NULL,
+  is_notice smallint NOT NULL DEFAULT 0,
+  regtime timestamp DEFAULT NULL,
+  expiretime timestamp DEFAULT NULL,
+  checktime timestamp DEFAULT NULL,
+  noticetime timestamp DEFAULT NULL,
+  checkstatus smallint NOT NULL DEFAULT 0
+);
+CREATE INDEX dnsmgr_domain_name_idx ON dnsmgr_domain (name);
+
+DROP TABLE IF EXISTS dnsmgr_user;
+CREATE TABLE dnsmgr_user (
+  id integer NOT NULL,
+  username varchar(64) NOT NULL,
+  password varchar(80) NOT NULL,
+  is_api smallint NOT NULL DEFAULT 0,
+  apikey varchar(32) DEFAULT NULL,
+  level integer NOT NULL DEFAULT 0,
+  regtime timestamp DEFAULT NULL,
+  lasttime timestamp DEFAULT NULL,
+  totp_open smallint NOT NULL DEFAULT 0,
+  totp_secret varchar(100) DEFAULT NULL,
+  status smallint NOT NULL DEFAULT 1,
+  PRIMARY KEY (id)
+);
+CREATE SEQUENCE dnsmgr_user_id_seq START 1000 OWNED BY dnsmgr_user.id;
+ALTER TABLE dnsmgr_user ALTER COLUMN id SET DEFAULT nextval('dnsmgr_user_id_seq');
+CREATE INDEX dnsmgr_user_username_idx ON dnsmgr_user (username);
+
+DROP TABLE IF EXISTS dnsmgr_permission;
+CREATE TABLE dnsmgr_permission (
+  id serial PRIMARY KEY,
+  uid integer NOT NULL,
+  domain varchar(255) NOT NULL,
+  sub varchar(80) DEFAULT NULL
+);
+CREATE INDEX dnsmgr_permission_uid_idx ON dnsmgr_permission (uid);
+
+DROP TABLE IF EXISTS dnsmgr_log;
+CREATE TABLE dnsmgr_log (
+  id serial PRIMARY KEY,
+  uid integer NOT NULL,
+  action varchar(40) NOT NULL,
+  domain varchar(255) NOT NULL DEFAULT '',
+  data varchar(500) DEFAULT NULL,
+  addtime timestamp NOT NULL
+);
+CREATE INDEX dnsmgr_log_uid_idx ON dnsmgr_log (uid);
+CREATE INDEX dnsmgr_log_domain_idx ON dnsmgr_log (domain);
+
+DROP TABLE IF EXISTS dnsmgr_dmtask;
+CREATE TABLE dnsmgr_dmtask (
+  id serial PRIMARY KEY,
+  did integer NOT NULL,
+  rr varchar(128) NOT NULL,
+  recordid varchar(60) NOT NULL,
+  type smallint NOT NULL DEFAULT 0,
+  main_value varchar(128) DEFAULT NULL,
+  backup_value varchar(128) DEFAULT NULL,
+  checktype smallint NOT NULL DEFAULT 0,
+  checkurl varchar(512) DEFAULT NULL,
+  tcpport integer DEFAULT NULL,
+  frequency smallint NOT NULL,
+  cycle smallint NOT NULL DEFAULT 3,
+  timeout smallint NOT NULL DEFAULT 2,
+  remark varchar(100) DEFAULT NULL,
+  proxy smallint NOT NULL DEFAULT 0,
+  cdn smallint NOT NULL DEFAULT 0,
+  addtime integer NOT NULL DEFAULT 0,
+  checktime integer NOT NULL DEFAULT 0,
+  checknexttime integer NOT NULL DEFAULT 0,
+  switchtime integer NOT NULL DEFAULT 0,
+  errcount smallint NOT NULL DEFAULT 0,
+  status smallint NOT NULL DEFAULT 0,
+  active smallint NOT NULL DEFAULT 0,
+  recordinfo varchar(200) DEFAULT NULL
+);
+CREATE INDEX dnsmgr_dmtask_did_idx ON dnsmgr_dmtask (did);
+
+DROP TABLE IF EXISTS dnsmgr_dmlog;
+CREATE TABLE dnsmgr_dmlog (
+  id serial PRIMARY KEY,
+  taskid integer NOT NULL,
+  action smallint NOT NULL DEFAULT 0,
+  errmsg varchar(100) DEFAULT NULL,
+  date timestamp DEFAULT NULL
+);
+CREATE INDEX dnsmgr_dmlog_taskid_idx ON dnsmgr_dmlog (taskid);
+CREATE INDEX dnsmgr_dmlog_date_idx ON dnsmgr_dmlog (date);
+
+DROP TABLE IF EXISTS dnsmgr_optimizeip;
+CREATE TABLE dnsmgr_optimizeip (
+  id serial PRIMARY KEY,
+  did integer NOT NULL,
+  rr varchar(128) NOT NULL,
+  type smallint NOT NULL DEFAULT 0,
+  ip_type varchar(10) NOT NULL,
+  cdn_type smallint NOT NULL DEFAULT 1,
+  recordnum smallint NOT NULL DEFAULT 2,
+  ttl integer NOT NULL DEFAULT 600,
+  remark varchar(100) DEFAULT NULL,
+  addtime timestamp NOT NULL,
+  updatetime timestamp DEFAULT NULL,
+  status smallint NOT NULL DEFAULT 0,
+  active smallint NOT NULL DEFAULT 0,
+  errmsg varchar(100) DEFAULT NULL
+);
+CREATE INDEX dnsmgr_optimizeip_did_idx ON dnsmgr_optimizeip (did);
+
+DROP TABLE IF EXISTS dnsmgr_cert_account;
+CREATE TABLE dnsmgr_cert_account (
+  id serial PRIMARY KEY,
+  type varchar(20) NOT NULL,
+  name varchar(255) NOT NULL,
+  config text DEFAULT NULL,
+  ext text DEFAULT NULL,
+  remark varchar(100) DEFAULT NULL,
+  deploy smallint NOT NULL DEFAULT 0,
+  addtime timestamp DEFAULT NULL
+);
+
+DROP TABLE IF EXISTS dnsmgr_cert_order;
+CREATE TABLE dnsmgr_cert_order (
+  id serial PRIMARY KEY,
+  aid integer NOT NULL,
+  keytype varchar(20) DEFAULT NULL,
+  keysize varchar(20) DEFAULT NULL,
+  addtime timestamp DEFAULT NULL,
+  updatetime timestamp DEFAULT NULL,
+  processid varchar(32) DEFAULT NULL,
+  issuetime timestamp DEFAULT NULL,
+  expiretime timestamp DEFAULT NULL,
+  issuer varchar(100) DEFAULT NULL,
+  status smallint NOT NULL DEFAULT 0,
+  error varchar(300) DEFAULT NULL,
+  isauto smallint NOT NULL DEFAULT 0,
+  retry smallint NOT NULL DEFAULT 0,
+  retry2 smallint NOT NULL DEFAULT 0,
+  retrytime timestamp DEFAULT NULL,
+  islock smallint NOT NULL DEFAULT 0,
+  locktime timestamp DEFAULT NULL,
+  issend smallint NOT NULL DEFAULT 0,
+  info text DEFAULT NULL,
+  dns text DEFAULT NULL,
+  fullchain text DEFAULT NULL,
+  privatekey text DEFAULT NULL
+);
+
+DROP TABLE IF EXISTS dnsmgr_cert_domain;
+CREATE TABLE dnsmgr_cert_domain (
+  id serial PRIMARY KEY,
+  oid integer NOT NULL,
+  domain varchar(255) NOT NULL,
+  sort integer NOT NULL DEFAULT 0
+);
+CREATE INDEX dnsmgr_cert_domain_oid_idx ON dnsmgr_cert_domain (oid);
+
+DROP TABLE IF EXISTS dnsmgr_cert_deploy;
+CREATE TABLE dnsmgr_cert_deploy (
+  id serial PRIMARY KEY,
+  aid integer NOT NULL,
+  oid integer NOT NULL,
+  issuetime timestamp DEFAULT NULL,
+  config text DEFAULT NULL,
+  remark varchar(100) DEFAULT NULL,
+  addtime timestamp DEFAULT NULL,
+  lasttime timestamp DEFAULT NULL,
+  processid varchar(32) DEFAULT NULL,
+  status smallint NOT NULL DEFAULT 0,
+  error varchar(300) DEFAULT NULL,
+  active smallint NOT NULL DEFAULT 0,
+  retry smallint NOT NULL DEFAULT 0,
+  retrytime timestamp DEFAULT NULL,
+  islock smallint NOT NULL DEFAULT 0,
+  locktime timestamp DEFAULT NULL,
+  issend smallint NOT NULL DEFAULT 0,
+  info text DEFAULT NULL
+);
+
+DROP TABLE IF EXISTS dnsmgr_cert_cname;
+CREATE TABLE dnsmgr_cert_cname (
+  id serial PRIMARY KEY,
+  domain varchar(255) NOT NULL,
+  did integer NOT NULL,
+  rr varchar(128) NOT NULL,
+  addtime timestamp DEFAULT NULL,
+  status smallint NOT NULL DEFAULT 0
+);
+
+DROP TABLE IF EXISTS dnsmgr_sctask;
+CREATE TABLE dnsmgr_sctask (
+  id serial PRIMARY KEY,
+  did integer NOT NULL,
+  rr varchar(128) NOT NULL,
+  recordid varchar(60) NOT NULL,
+  type smallint NOT NULL DEFAULT 0,
+  cycle smallint NOT NULL DEFAULT 0,
+  switchtype smallint NOT NULL DEFAULT 0,
+  switchdate varchar(10) DEFAULT NULL,
+  switchtime varchar(20) DEFAULT NULL,
+  value varchar(128) DEFAULT NULL,
+  line varchar(20) DEFAULT NULL,
+  addtime integer NOT NULL DEFAULT 0,
+  updatetime integer NOT NULL DEFAULT 0,
+  nexttime integer NOT NULL DEFAULT 0,
+  active smallint NOT NULL DEFAULT 0,
+  recordinfo varchar(200) DEFAULT NULL,
+  remark varchar(100) DEFAULT NULL
+);
+CREATE INDEX dnsmgr_sctask_did_idx ON dnsmgr_sctask (did);
+
+DROP TABLE IF EXISTS dnsmgr_domain_alias;
+CREATE TABLE dnsmgr_domain_alias (
+  id serial PRIMARY KEY,
+  did integer NOT NULL,
+  name varchar(255) NOT NULL
+);
+CREATE INDEX dnsmgr_domain_alias_did_idx ON dnsmgr_domain_alias (did);
+CREATE INDEX dnsmgr_domain_alias_name_idx ON dnsmgr_domain_alias (name);

--- a/app/sql/update.pgsql.sql
+++ b/app/sql/update.pgsql.sql
@@ -1,0 +1,183 @@
+CREATE TABLE IF NOT EXISTS dnsmgr_config (
+  "key" varchar(32) NOT NULL,
+  value text DEFAULT NULL,
+  PRIMARY KEY ("key")
+);
+
+CREATE TABLE IF NOT EXISTS dnsmgr_dmtask (
+  id serial PRIMARY KEY,
+  did integer NOT NULL,
+  rr varchar(128) NOT NULL,
+  recordid varchar(60) NOT NULL,
+  type smallint NOT NULL DEFAULT 0,
+  main_value varchar(128) DEFAULT NULL,
+  backup_value varchar(128) DEFAULT NULL,
+  checktype smallint NOT NULL DEFAULT 0,
+  checkurl varchar(512) DEFAULT NULL,
+  tcpport integer DEFAULT NULL,
+  frequency smallint NOT NULL,
+  cycle smallint NOT NULL DEFAULT 3,
+  timeout smallint NOT NULL DEFAULT 2,
+  remark varchar(100) DEFAULT NULL,
+  addtime integer NOT NULL DEFAULT 0,
+  checktime integer NOT NULL DEFAULT 0,
+  checknexttime integer NOT NULL DEFAULT 0,
+  switchtime integer NOT NULL DEFAULT 0,
+  errcount smallint NOT NULL DEFAULT 0,
+  status smallint NOT NULL DEFAULT 0,
+  active smallint NOT NULL DEFAULT 0,
+  recordinfo varchar(200) DEFAULT NULL
+);
+CREATE INDEX IF NOT EXISTS dnsmgr_dmtask_did_idx ON dnsmgr_dmtask (did);
+
+CREATE TABLE IF NOT EXISTS dnsmgr_dmlog (
+  id serial PRIMARY KEY,
+  taskid integer NOT NULL,
+  action smallint NOT NULL DEFAULT 0,
+  errmsg varchar(100) DEFAULT NULL,
+  date timestamp DEFAULT NULL
+);
+CREATE INDEX IF NOT EXISTS dnsmgr_dmlog_taskid_idx ON dnsmgr_dmlog (taskid);
+CREATE INDEX IF NOT EXISTS dnsmgr_dmlog_date_idx ON dnsmgr_dmlog (date);
+
+CREATE TABLE IF NOT EXISTS dnsmgr_optimizeip (
+  id serial PRIMARY KEY,
+  did integer NOT NULL,
+  rr varchar(128) NOT NULL,
+  type smallint NOT NULL DEFAULT 0,
+  ip_type varchar(10) NOT NULL,
+  cdn_type smallint NOT NULL DEFAULT 1,
+  recordnum smallint NOT NULL DEFAULT 2,
+  ttl integer NOT NULL DEFAULT 600,
+  remark varchar(100) DEFAULT NULL,
+  addtime timestamp NOT NULL,
+  updatetime timestamp DEFAULT NULL,
+  status smallint NOT NULL DEFAULT 0,
+  active smallint NOT NULL DEFAULT 0,
+  errmsg varchar(100) DEFAULT NULL
+);
+CREATE INDEX IF NOT EXISTS dnsmgr_optimizeip_did_idx ON dnsmgr_optimizeip (did);
+
+ALTER TABLE dnsmgr_domain ADD COLUMN IF NOT EXISTS remark varchar(100) DEFAULT NULL;
+
+ALTER TABLE dnsmgr_dmtask ADD COLUMN IF NOT EXISTS proxy smallint NOT NULL DEFAULT 0;
+
+ALTER TABLE dnsmgr_user ADD COLUMN IF NOT EXISTS totp_open smallint NOT NULL DEFAULT 0;
+ALTER TABLE dnsmgr_user ADD COLUMN IF NOT EXISTS totp_secret varchar(100) DEFAULT NULL;
+
+CREATE TABLE IF NOT EXISTS dnsmgr_cert_account (
+  id serial PRIMARY KEY,
+  type varchar(20) NOT NULL,
+  name varchar(255) NOT NULL,
+  config text DEFAULT NULL,
+  ext text DEFAULT NULL,
+  remark varchar(100) DEFAULT NULL,
+  deploy smallint NOT NULL DEFAULT 0,
+  addtime timestamp DEFAULT NULL
+);
+
+CREATE TABLE IF NOT EXISTS dnsmgr_cert_order (
+  id serial PRIMARY KEY,
+  aid integer NOT NULL,
+  keytype varchar(20) DEFAULT NULL,
+  keysize varchar(20) DEFAULT NULL,
+  addtime timestamp DEFAULT NULL,
+  updatetime timestamp DEFAULT NULL,
+  processid varchar(32) DEFAULT NULL,
+  issuetime timestamp DEFAULT NULL,
+  expiretime timestamp DEFAULT NULL,
+  issuer varchar(100) DEFAULT NULL,
+  status smallint NOT NULL DEFAULT 0,
+  error varchar(300) DEFAULT NULL,
+  isauto smallint NOT NULL DEFAULT 0,
+  retry smallint NOT NULL DEFAULT 0,
+  retry2 smallint NOT NULL DEFAULT 0,
+  retrytime timestamp DEFAULT NULL,
+  islock smallint NOT NULL DEFAULT 0,
+  locktime timestamp DEFAULT NULL,
+  issend smallint NOT NULL DEFAULT 0,
+  info text DEFAULT NULL,
+  dns text DEFAULT NULL,
+  fullchain text DEFAULT NULL,
+  privatekey text DEFAULT NULL
+);
+
+CREATE TABLE IF NOT EXISTS dnsmgr_cert_domain (
+  id serial PRIMARY KEY,
+  oid integer NOT NULL,
+  domain varchar(255) NOT NULL,
+  sort integer NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS dnsmgr_cert_domain_oid_idx ON dnsmgr_cert_domain (oid);
+
+CREATE TABLE IF NOT EXISTS dnsmgr_cert_deploy (
+  id serial PRIMARY KEY,
+  aid integer NOT NULL,
+  oid integer NOT NULL,
+  issuetime timestamp DEFAULT NULL,
+  config text DEFAULT NULL,
+  remark varchar(100) DEFAULT NULL,
+  addtime timestamp DEFAULT NULL,
+  lasttime timestamp DEFAULT NULL,
+  processid varchar(32) DEFAULT NULL,
+  status smallint NOT NULL DEFAULT 0,
+  error varchar(300) DEFAULT NULL,
+  active smallint NOT NULL DEFAULT 0,
+  retry smallint NOT NULL DEFAULT 0,
+  retrytime timestamp DEFAULT NULL,
+  islock smallint NOT NULL DEFAULT 0,
+  locktime timestamp DEFAULT NULL,
+  issend smallint NOT NULL DEFAULT 0,
+  info text DEFAULT NULL
+);
+
+CREATE TABLE IF NOT EXISTS dnsmgr_cert_cname (
+  id serial PRIMARY KEY,
+  domain varchar(255) NOT NULL,
+  did integer NOT NULL,
+  rr varchar(128) NOT NULL,
+  addtime timestamp DEFAULT NULL,
+  status smallint NOT NULL DEFAULT 0
+);
+
+ALTER TABLE dnsmgr_account ADD COLUMN IF NOT EXISTS proxy smallint NOT NULL DEFAULT 0;
+
+ALTER TABLE dnsmgr_dmtask ADD COLUMN IF NOT EXISTS cdn smallint NOT NULL DEFAULT 0;
+
+ALTER TABLE dnsmgr_domain ADD COLUMN IF NOT EXISTS is_notice smallint NOT NULL DEFAULT 0;
+ALTER TABLE dnsmgr_domain ADD COLUMN IF NOT EXISTS regtime timestamp DEFAULT NULL;
+ALTER TABLE dnsmgr_domain ADD COLUMN IF NOT EXISTS expiretime timestamp DEFAULT NULL;
+ALTER TABLE dnsmgr_domain ADD COLUMN IF NOT EXISTS checktime timestamp DEFAULT NULL;
+ALTER TABLE dnsmgr_domain ADD COLUMN IF NOT EXISTS noticetime timestamp DEFAULT NULL;
+ALTER TABLE dnsmgr_domain ADD COLUMN IF NOT EXISTS checkstatus smallint NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS dnsmgr_sctask (
+  id serial PRIMARY KEY,
+  did integer NOT NULL,
+  rr varchar(128) NOT NULL,
+  recordid varchar(60) NOT NULL,
+  type smallint NOT NULL DEFAULT 0,
+  cycle smallint NOT NULL DEFAULT 0,
+  switchtype smallint NOT NULL DEFAULT 0,
+  switchdate varchar(10) DEFAULT NULL,
+  switchtime varchar(20) DEFAULT NULL,
+  value varchar(128) DEFAULT NULL,
+  line varchar(20) DEFAULT NULL,
+  addtime integer NOT NULL DEFAULT 0,
+  updatetime integer NOT NULL DEFAULT 0,
+  nexttime integer NOT NULL DEFAULT 0,
+  active smallint NOT NULL DEFAULT 0,
+  recordinfo varchar(200) DEFAULT NULL,
+  remark varchar(100) DEFAULT NULL
+);
+CREATE INDEX IF NOT EXISTS dnsmgr_sctask_did_idx ON dnsmgr_sctask (did);
+
+ALTER TABLE dnsmgr_account ADD COLUMN IF NOT EXISTS config text DEFAULT NULL;
+
+CREATE TABLE IF NOT EXISTS dnsmgr_domain_alias (
+  id serial PRIMARY KEY,
+  did integer NOT NULL,
+  name varchar(255) NOT NULL
+);
+CREATE INDEX IF NOT EXISTS dnsmgr_domain_alias_did_idx ON dnsmgr_domain_alias (did);
+CREATE INDEX IF NOT EXISTS dnsmgr_domain_alias_name_idx ON dnsmgr_domain_alias (name);

--- a/app/utils/CertDnsUtils.php
+++ b/app/utils/CertDnsUtils.php
@@ -12,9 +12,9 @@ class CertDnsUtils
     {
         $cnameDomainList = [];
         foreach ($dnsList as $mainDomain => $list) {
-            $drow = Db::name('domain')->alias('A')->join('account B', 'A.aid = B.id')->where('A.name', $mainDomain)->field('A.*,B.type')->find();
+            $drow = Db::name('domain')->alias('a')->join('account b', 'a.aid = b.id')->where('a.name', $mainDomain)->field('a.*,b.type')->find();
             if (!$drow && preg_match('/^xn--/', $mainDomain)) {
-                $drow = Db::name('domain')->alias('A')->join('account B', 'A.aid = B.id')->where('A.name', idn_to_utf8($mainDomain))->field('A.*,B.type')->find();
+                $drow = Db::name('domain')->alias('a')->join('account b', 'a.aid = b.id')->where('a.name', idn_to_utf8($mainDomain))->field('a.*,b.type')->find();
             }
             if (!$drow) {
                 if ($cname) {
@@ -24,7 +24,7 @@ class CertDnsUtils
                         } else {
                             $domain = str_replace('_acme-challenge.', '', $row['name']) . '.' . $mainDomain;
                         }
-                        $cname_row = Db::name('cert_cname')->alias('A')->join('domain B', 'A.did = B.id')->where('A.domain', $domain)->field('A.*,B.name cnamedomain')->find();
+                        $cname_row = Db::name('cert_cname')->alias('a')->join('domain b', 'a.did = b.id')->where('a.domain', $domain)->field('a.*,b.name cnamedomain')->find();
                         if ($cname_row) {
                             $row['name'] = $cname_row['rr'];
                             $cnameDomainList[$cname_row['cnamedomain']][] = $row;
@@ -104,9 +104,9 @@ class CertDnsUtils
     {
         $cnameDomainList = [];
         foreach ($dnsList as $mainDomain => $list) {
-            $drow = Db::name('domain')->alias('A')->join('account B', 'A.aid = B.id')->where('A.name', $mainDomain)->field('A.*,B.type')->find();
+            $drow = Db::name('domain')->alias('a')->join('account b', 'a.aid = b.id')->where('a.name', $mainDomain)->field('a.*,b.type')->find();
             if (!$drow && preg_match('/^xn--/', $mainDomain)) {
-                $drow = Db::name('domain')->alias('A')->join('account B', 'A.aid = B.id')->where('A.name', idn_to_utf8($mainDomain))->field('A.*,B.type')->find();
+                $drow = Db::name('domain')->alias('a')->join('account b', 'a.aid = b.id')->where('a.name', idn_to_utf8($mainDomain))->field('a.*,b.type')->find();
             }
             if (!$drow) {
                 if ($cname) {
@@ -116,7 +116,7 @@ class CertDnsUtils
                         } else {
                             $domain = str_replace('_acme-challenge.', '', $row['name']) . '.' . $mainDomain;
                         }
-                        $cname_row = Db::name('cert_cname')->alias('A')->join('domain B', 'A.did = B.id')->where('A.domain', $domain)->field('A.*,B.name cnamedomain')->find();
+                        $cname_row = Db::name('cert_cname')->alias('a')->join('domain b', 'a.did = b.id')->where('a.domain', $domain)->field('a.*,b.name cnamedomain')->find();
                         if ($cname_row) {
                             $row['name'] = $cname_row['rr'];
                             $cnameDomainList[$cname_row['cnamedomain']][] = $row;

--- a/app/view/install/index.html
+++ b/app/view/install/index.html
@@ -165,32 +165,40 @@
             {if $dbconfig!='1'}
             <div class="form-group">
                 <div class="form-field">
-                    <label>MySQL 数据库地址</label>
+                    <label>数据库类型</label>
+                    <select name="db_type" style="width:100%;padding:15px 15px 15px 180px;border:2px solid transparent;background:#fff;box-sizing:border-box;">
+                        <option value="mysql">MySQL / MariaDB</option>
+                        <option value="pgsql">PostgreSQL</option>
+                    </select>
+                </div>
+
+                <div class="form-field">
+                    <label>数据库地址</label>
                     <input type="text" name="mysql_host" value="localhost" required="">
                 </div>
 
                 <div class="form-field">
-                    <label>MySQL 数据库端口</label>
+                    <label>数据库端口</label>
                     <input type="number" name="mysql_port" value="3306">
                 </div>
 
                 <div class="form-field">
-                    <label>MySQL 用户名</label>
+                    <label>用户名</label>
                     <input type="text" name="mysql_user" value="" required="">
                 </div>
 
                 <div class="form-field">
-                    <label>MySQL 密码</label>
+                    <label>密码</label>
                     <input type="text" name="mysql_pwd" value="" required="">
                 </div>
 
                 <div class="form-field">
-                    <label>MySQL 数据库名</label>
+                    <label>数据库名</label>
                     <input type="text" name="mysql_name" value="" required="">
                 </div>
 
                 <div class="form-field">
-                    <label>MySQL 数据表前缀</label>
+                    <label>数据表前缀</label>
                     <input type="text" name="mysql_prefix" value="dnsmgr_">
                 </div>
             </div>
@@ -219,6 +227,11 @@
 <script src="//cdn.staticfile.org/jquery/2.1.4/jquery.min.js"></script>
 <script>
     $(function () {
+        $('select[name="db_type"]').on('change', function () {
+            var type = $(this).val();
+            $('input[name="mysql_port"]').val(type === 'pgsql' ? 5432 : 3306);
+            $('input[name="mysql_user"]').val(type === 'pgsql' ? 'postgres' : '');
+        });
         $('form').on('submit', function (e) {
             e.preventDefault();
             var form = this;

--- a/config/database.php
+++ b/config/database.php
@@ -58,6 +58,40 @@ return [
             'fields_cache'    => true,
         ],
 
+        'pgsql' => [
+            // 数据库类型
+            'type'            => 'pgsql',
+            // 自定义 builder：修复 pdo_pgsql 多行 INSERT 时的类型推断问题
+            'builder'         => '\\app\\db\\builder\\Pgsql',
+            // 服务器地址
+            'hostname'        => env('database.hostname', '127.0.0.1'),
+            // 数据库名
+            'database'        => env('database.database', ''),
+            // 用户名
+            'username'        => env('database.username', 'postgres'),
+            // 密码
+            'password'        => env('database.password', ''),
+            // 端口
+            'hostport'        => env('database.hostport', '5432'),
+            // 数据库连接参数
+            'params'          => [],
+            // 数据库编码默认采用utf8
+            'charset'         => env('database.charset', 'utf8'),
+            // 数据库 schema
+            'schema'          => env('database.schema', 'public'),
+            // 数据库表前缀
+            'prefix'          => env('database.prefix', ''),
+
+            'deploy'          => 0,
+            'rw_separate'     => false,
+            'master_num'      => 1,
+            'slave_no'        => '',
+            'fields_strict'   => true,
+            'break_reconnect' => true,
+            'trigger_sql'     => env('app_debug', true),
+            'fields_cache'    => true,
+        ],
+
         // 更多的数据库配置信息
     ],
 ];


### PR DESCRIPTION
新增
- 安装/升级脚本：app/sql/install.pgsql.sql、app/sql/update.pgsql.sql
- 自定义 PG builder：app/db/builder/Pgsql.php 
  - insertAll/insertAllByKeys 使用多行 VALUES (PDO_PgSQL 把所有占位符发为 text，原 INSERT … SELECT … UNION ALL 模板会导致 PG 把 int 列推断成 text，触发 42804)
  - parseLike 把 LIKE 改写为 ILIKE，兼容 MySQL 默认大小写不敏感行为
- config/database.php 增加 pgsql 连接块，默认 builder 指向上述自定义类

修改
- config/database.php default 由 database.driver 环境变量决定，原 mysql路径不变
- .example.env 引入 {dbdriver}/{dbtype} 占位符
- app/controller/Install.php 接受 db_type，按驱动加载对应 install SQL，构造 PDO DSN，生成方言对应的种子 SQL（PG: ON CONFLICT，MySQL: REPLACE INTO）
- app/view/install/index.html 新增数据库类型下拉框
- app/controller/Index.php
  - select version() as v 取列别名以兼容 PG 
  - db_update 按驱动选 update.{type}.sql
- app/controller/Dmonitor.php::clean 按驱动分支，PG 使用 VACUUM 替代 OPTIMIZE TABLE，删除硬编码 connections.mysql.prefix
- app/common.php
  - checkTableExists 使用 Db::getConnection()->getTables() 替代 SHOW TABLES LIKE 
  - config_set 使用 update/insert 避免 PG replace()->insert() 退化为普通 INSERT 触发 23505
- app/service/ExpireNoticeService.php 替换 whereRaw 中 INTERVAL N DAY/HOUR 为 PHP 计算时间戳后传入查询构造器
- 修改 ThinkPHP 查询别名 A/B/C/D 改为小写 (a/b/c/d) 以规避 PG builder 别名的保留大小写；修复 fieldRaw 中的裸 A.* 会被折叠成 a.*，导致 missing FROM-clause entry。