### PR TITLE
refactor: 重构分页系统，统一使用localStorage持久化分页大小

### DIFF
--- a/app/BaseController.php
+++ b/app/BaseController.php
@@ -96,6 +96,11 @@ abstract class BaseController
         return $v->failException(true)->check($data);
     }
 
+    protected function validateLimit(int $limit, int $default = 15): int
+    {
+        $validSizes = [10, 15, 20, 30, 50, 100, 200, 300, 500];
+        return in_array($limit, $validSizes) ? $limit : $default;
+    }
 
     protected function alert($code, $msg = '', $url = null, $wait = 3)
     {

--- a/app/controller/Cert.php
+++ b/app/controller/Cert.php
@@ -33,6 +33,7 @@ class Cert extends BaseController
         $kw = $this->request->post('kw', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
 
         $select = Db::name('cert_account')->where('deploy', $deploy);
         if (!empty($kw)) {
@@ -216,6 +217,7 @@ class Cert extends BaseController
         $status = input('post.status', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
 
         $select = Db::name('cert_order')->alias('A')->leftJoin('cert_account B', 'A.aid = B.id');
         if (!empty($id)) {
@@ -650,6 +652,7 @@ class Cert extends BaseController
         $remark = input('post.remark', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
 
         $select = Db::name('cert_deploy')->alias('A')->leftJoin('cert_account B', 'A.aid = B.id')->leftJoin('cert_order C', 'A.oid = C.id')->leftJoin('cert_account D', 'C.aid = D.id');
         if (!empty($oid)) {
@@ -862,6 +865,7 @@ class Cert extends BaseController
         $kw = $this->request->post('kw', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
 
         $select = Db::name('cert_cname')->alias('A')->leftJoin('domain B', 'A.did = B.id');
         if (!empty($kw)) {

--- a/app/controller/Dmonitor.php
+++ b/app/controller/Dmonitor.php
@@ -43,6 +43,7 @@ class Dmonitor extends BaseController
         $kw = input('post.kw', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
 
         $select = Db::name('dmtask')->alias('A')->join('domain B', 'A.did = B.id');
         if (!empty($kw)) {
@@ -233,6 +234,7 @@ class Dmonitor extends BaseController
         $taskid = input('param.id/d');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
         $action = input('post.action/d', 0);
 
         $select = Db::name('dmlog')->where('taskid', $taskid);

--- a/app/controller/Domain.php
+++ b/app/controller/Domain.php
@@ -26,6 +26,7 @@ class Domain extends BaseController
         $kw = $this->request->post('kw', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
 
         $select = Db::name('account');
         if (!empty($kw)) {
@@ -195,6 +196,7 @@ class Domain extends BaseController
         $order = input('post.order', null, 'trim');
         $offset = input('post.offset/d', 0);
         $limit = input('post.limit/d', 10);
+        $limit = $this->validateLimit($limit);
         $id = input('post.id');
         $aid = input('post.aid', null, 'trim');
 
@@ -381,6 +383,7 @@ class Domain extends BaseController
         $kw = input('post.kw', null, 'trim');
         $page = input('?post.page') ? input('post.page/d') : 1;
         $pagesize = input('?post.pagesize') ? input('post.pagesize/d') : 10;
+        $pagesize = $this->validateLimit($pagesize);
         $dns = DnsHelper::getModel($aid);
         $result = $dns->getDomainList($kw, $page, $pagesize);
         if (!$result) return json(['code' => -1, 'msg' => '获取域名列表失败，' . $dns->getError()]);
@@ -486,6 +489,7 @@ class Domain extends BaseController
         $status = input('post.status', null, 'trim');
         $offset = input('post.offset/d', 0);
         $limit = input('post.limit/d', 10);
+        $limit = $this->validateLimit($limit);
         if ($limit == 0) {
             $page = 1;
         } else {
@@ -1016,6 +1020,7 @@ class Domain extends BaseController
         if (request()->isPost()) {
             $offset = input('post.offset/d');
             $limit = input('post.limit/d');
+            $limit = $this->validateLimit($limit);
             $page = $offset / $limit + 1;
             $dns = DnsHelper::getModel($drow['aid'], $drow['name'], $drow['thirdid']);
             $domainRecords = $dns->getDomainRecordLog($page, $limit);
@@ -1210,6 +1215,7 @@ class Domain extends BaseController
         $keyword = input('post.keyword', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
         if ($limit == 0) {
             $page = 1;
         } else {
@@ -1392,6 +1398,7 @@ class Domain extends BaseController
         if (!checkPermission(2)) return json(['total' => 0, 'rows' => []]);
         $offset = input('post.offset/d', 0);
         $limit = input('post.limit/d', 10);
+        $limit = $this->validateLimit($limit);
 
         $select = Db::name('domain_category');
         $total = $select->count();

--- a/app/controller/Optimizeip.php
+++ b/app/controller/Optimizeip.php
@@ -45,6 +45,7 @@ class Optimizeip extends BaseController
         $status = input('post.status', null);
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
 
         $select = Db::name('optimizeip')->alias('A')->join('domain B', 'A.did = B.id');
         if (!empty($kw)) {

--- a/app/controller/Schedule.php
+++ b/app/controller/Schedule.php
@@ -24,6 +24,7 @@ class Schedule extends BaseController
         $stype = input('post.stype', null);
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
 
         $select = Db::name('sctask')->alias('A')->join('domain B', 'A.did = B.id');
         if (!empty($kw)) {

--- a/app/controller/User.php
+++ b/app/controller/User.php
@@ -28,6 +28,7 @@ class User extends BaseController
         $kw = input('post.kw', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
 
         $select = Db::name('user');
         if (!empty($kw)) {
@@ -165,6 +166,7 @@ class User extends BaseController
         $domain = input('post.domain', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $limit = $this->validateLimit($limit);
 
         $select = Db::name('log');
         if ($this->request->user['type'] == 'domain') {

--- a/app/view/cert/certaccount.html
+++ b/app/view/cert/certaccount.html
@@ -31,9 +31,9 @@
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'certaccount_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/cert/account/data?deploy=0',
@@ -72,7 +72,10 @@ $(document).ready(function(){
 					return html;
 				}
 			},
-		]
+		],
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 function delItem(id){

--- a/app/view/cert/certaccount.html
+++ b/app/view/cert/certaccount.html
@@ -27,7 +27,7 @@
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/app/view/cert/certorder.html
+++ b/app/view/cert/certorder.html
@@ -55,7 +55,7 @@ pre.pre-log{height: 330px;overflow-y: auto;width: 100%;background-color: rgba(51
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
 <script src="/static/js/FileSaver-2.0.5.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/app/view/cert/certorder.html
+++ b/app/view/cert/certorder.html
@@ -59,9 +59,9 @@ pre.pre-log{height: 330px;overflow-y: auto;width: 100%;background-color: rgba(51
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 10;
+	const pageSizeKey = 'certorder_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/cert/order/data',
@@ -252,7 +252,10 @@ $(document).ready(function(){
 				}
 				$(e.target).children('.dropdown-menu').css({position:'fixed', top:top, left:left});
 			});
-		}
+		},
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 function showmsg(msg){

--- a/app/view/cert/cname.html
+++ b/app/view/cert/cname.html
@@ -74,7 +74,7 @@ tbody tr>td:nth-child(4){word-break:break-all;max-width:260px;}
 <script src="/static/js/clipboard-1.7.1.min.js"></script>
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/app/view/cert/cname.html
+++ b/app/view/cert/cname.html
@@ -78,9 +78,9 @@ tbody tr>td:nth-child(4){word-break:break-all;max-width:260px;}
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'cname_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/cert/cname/data',
@@ -146,6 +146,9 @@ $(document).ready(function(){
 			clipboard.on('error', function (e) {
 				layer.msg('复制失败', {icon: 2});
 			});
+		},
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
 		},
 	})
 })

--- a/app/view/cert/deployaccount.html
+++ b/app/view/cert/deployaccount.html
@@ -27,7 +27,7 @@
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/app/view/cert/deployaccount.html
+++ b/app/view/cert/deployaccount.html
@@ -31,9 +31,9 @@
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'deployaccount_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/cert/account/data?deploy=1',
@@ -72,7 +72,10 @@ $(document).ready(function(){
 					return html;
 				}
 			},
-		]
+		],
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 function delItem(id){

--- a/app/view/cert/deploytask.html
+++ b/app/view/cert/deploytask.html
@@ -58,9 +58,9 @@ pre.pre-log{height: 330px;overflow-y: auto;width: 100%;background-color: rgba(51
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 10;
+	const pageSizeKey = 'deploytask_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/cert/deploy/data',
@@ -173,7 +173,10 @@ $(document).ready(function(){
 				}
 				$(e.target).children('.dropdown-menu').css({position:'fixed', top:top, left:left});
 			});
-		}
+		},
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 function showmsg(msg){

--- a/app/view/cert/deploytask.html
+++ b/app/view/cert/deploytask.html
@@ -54,7 +54,7 @@ pre.pre-log{height: 330px;overflow-y: auto;width: 100%;background-color: rgba(51
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
 <script src="/static/js/FileSaver-2.0.5.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/app/view/cloudflare/hostnames.html
+++ b/app/view/cloudflare/hostnames.html
@@ -458,7 +458,7 @@
 <script src="/static/js/bootstrapValidator.min.js"></script>
 <script src="/static/js/select2-4.0.13.min.js"></script>
 <script src="/static/js/select2-i18n-zh-CN-4.0.13.min.js"></script>
-<script src="/static/js/custom.js?v=1005"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 var currentVerificationHostnameId = '';
 var allHostnameData = []; // 保存完整的原始数据用于客户端搜索

--- a/app/view/cloudflare/hostnames.html
+++ b/app/view/cloudflare/hostnames.html
@@ -468,6 +468,7 @@ $(document).ready(function(){
   $("#form-store").bootstrapValidator();
   loadFallbackOrigin();
   loadDcvDelegationUuid();
+  const pageSizeKey = 'hostnames_pagesize';
   $("#listTable").bootstrapTable({
     url: '/cloudflare/hostnames/data/{$domainId}',
     method: 'post',
@@ -476,8 +477,7 @@ $(document).ready(function(){
     uniqueId: 'id',
     sidePagination: 'client',
     pagination: true,
-    pageSize: 20,
-    pageList: [10, 20, 50, 100],
+    pageSize: getStoredPageSize(pageSizeKey),
     queryParams: function(params){ return {}; },
     responseHandler: hostnameResponseHandler,
     columns: [
@@ -502,7 +502,10 @@ $(document).ready(function(){
             + '<a href="javascript:deleteHostname(\''+row.id+'\', \''+htmlEscape(row.hostname)+'\')" class="btn btn-danger btn-xs">删除</a>';
         }
       }
-    ]
+    ],
+    onPageChange: function(number, size){
+      setStoredPageSize(pageSizeKey, size);
+    },
   });
   
   // 添加复选框事件监听

--- a/app/view/cloudflare/tunnels.html
+++ b/app/view/cloudflare/tunnels.html
@@ -164,7 +164,7 @@
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
 <script src="/static/js/bootstrapValidator.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 var selectedTunnelId = '';
 var selectedTunnelName = '';

--- a/app/view/cloudflare/tunnels.html
+++ b/app/view/cloudflare/tunnels.html
@@ -172,12 +172,14 @@ var selectedTunnelName = '';
 $(document).ready(function(){
   $("#form-tunnel").bootstrapValidator();
 
+  const pageSizeKey = 'tunnels_pagesize';
   $("#listTable").bootstrapTable({
     url: '/cloudflare/tunnels/data/{$accountId}',
     method: 'post',
     toolbar: '',
     classes: 'table table-striped table-hover table-bordered',
     uniqueId: 'id',
+    pageSize: getStoredPageSize(pageSizeKey),
     responseHandler: tableResponseHandler,
     columns: [
       {field: 'name', title: '名称'},
@@ -197,7 +199,10 @@ $(document).ready(function(){
             + '<a href="javascript:deleteTunnel(\''+row.id+'\', \''+htmlEscape(row.name)+'\')" class="btn btn-danger btn-xs">删除</a>';
         }
       }
-    ]
+    ],
+    onPageChange: function(number, size){
+      setStoredPageSize(pageSizeKey, size);
+    },
   });
 
   $("#publicTable").bootstrapTable({

--- a/app/view/common/layout.html
+++ b/app/view/common/layout.html
@@ -255,6 +255,32 @@
 }, false);
 
 </script>
+<script>
+var VALID_PAGE_SIZES = [10, 15, 20, 30, 50, 100, 200, 300, 500];
+var DEFAULT_PAGE_SIZE = 15;
+
+function getStoredPageSize(key) {
+    var urlSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : null;
+    if (urlSize && VALID_PAGE_SIZES.indexOf(urlSize) !== -1) {
+        return urlSize;
+    }
+    var stored = localStorage.getItem(key);
+    if (stored) {
+        var storedSize = parseInt(stored);
+        if (VALID_PAGE_SIZES.indexOf(storedSize) !== -1) {
+            return storedSize;
+        }
+    }
+    return DEFAULT_PAGE_SIZE;
+}
+
+function setStoredPageSize(key, size) {
+    var intSize = parseInt(size);
+    if (VALID_PAGE_SIZES.indexOf(intSize) !== -1) {
+        localStorage.setItem(key, intSize);
+    }
+}
+</script>
 {block name="script"}{/block}
 </body>
 </html>

--- a/app/view/dmonitor/task.html
+++ b/app/view/dmonitor/task.html
@@ -45,7 +45,7 @@ tbody tr>td:nth-child(4){overflow: hidden;text-overflow: ellipsis;white-space: n
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/app/view/dmonitor/task.html
+++ b/app/view/dmonitor/task.html
@@ -49,9 +49,9 @@ tbody tr>td:nth-child(4){overflow: hidden;text-overflow: ellipsis;white-space: n
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'dmtask_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/dmonitor/task/data',
@@ -170,7 +170,10 @@ $(document).ready(function(){
 		],
 		onLoadSuccess: function(data) {
 			$('[data-toggle="tooltip"]').tooltip()
-		}
+		},
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 function setActive(id, active){

--- a/app/view/dmonitor/taskinfo.html
+++ b/app/view/dmonitor/taskinfo.html
@@ -37,9 +37,9 @@ tbody tr>td:nth-child(4){overflow: hidden;text-overflow: ellipsis;white-space: n
 var action_name = {$info.action_name|json_encode|raw};
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'dmtaskinfo_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/dmonitor/task/log/data/{$info.id}',
@@ -67,6 +67,9 @@ $(document).ready(function(){
 				title: '异常原因'
 			}
 		],
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 </script>

--- a/app/view/dmonitor/taskinfo.html
+++ b/app/view/dmonitor/taskinfo.html
@@ -32,7 +32,7 @@ tbody tr>td:nth-child(4){overflow: hidden;text-overflow: ellipsis;white-space: n
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 var action_name = {$info.action_name|json_encode|raw};
 $(document).ready(function(){

--- a/app/view/domain/account.html
+++ b/app/view/domain/account.html
@@ -32,9 +32,9 @@
 var userLevel = "{$user['level']|default=''}";
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'account_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/account/data',
@@ -78,6 +78,9 @@ $(document).ready(function(){
 				}
 			},
 		],
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 function delItem(id) {

--- a/app/view/domain/account.html
+++ b/app/view/domain/account.html
@@ -27,7 +27,7 @@
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 var userLevel = "{$user['level']|default=''}";
 $(document).ready(function(){

--- a/app/view/domain/alias.html
+++ b/app/view/domain/alias.html
@@ -65,7 +65,7 @@
 {/block}
 {block name="script"}
 <script src="/static/js/layer/layer.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 var domainId = {$domainId};
 

--- a/app/view/domain/category.html
+++ b/app/view/domain/category.html
@@ -65,9 +65,9 @@
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	let defaultPageSize = getCookie('category_pagesize') ? getCookie('category_pagesize') : 10;
+	const pageSizeKey = 'category_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/domain/category/data',
@@ -118,9 +118,7 @@ $(document).ready(function(){
 			},
 		],
 		onPageChange: function(number, size){
-			if(size != defaultPageSize){
-				setCookie('category_pagesize', size, 24 * 3600 * 30);
-			}
+			setStoredPageSize(pageSizeKey, size);
 		},
 	});
 

--- a/app/view/domain/category.html
+++ b/app/view/domain/category.html
@@ -61,7 +61,7 @@
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
 <script src="/static/js/bootstrapValidator.min.js"></script>
-<script src="/static/js/custom.js?v=1003"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/app/view/domain/domain.html
+++ b/app/view/domain/domain.html
@@ -189,9 +189,9 @@
 var userLevel = "{$user['level']|default=''}";
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = getCookie('domain_pagesize') ? getCookie('domain_pagesize') : 15;
+	const pageSizeKey = 'domain_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/domain/data',
@@ -326,9 +326,7 @@ $(document).ready(function(){
 			$('[data-toggle="tooltip"]').tooltip()
 		},
 		onPageChange: function(number, size){
-			if(size != defaultPageSize){
-				setCookie('domain_pagesize', size, 24 * 3600 * 30);
-			}
+			setStoredPageSize(pageSizeKey, size);
 		},
 	})
 

--- a/app/view/domain/domain.html
+++ b/app/view/domain/domain.html
@@ -184,7 +184,7 @@
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
 <script src="/static/js/select2-4.0.13.min.js"></script>
 <script src="/static/js/select2-i18n-zh-CN-4.0.13.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 var userLevel = "{$user['level']|default=''}";
 $(document).ready(function(){

--- a/app/view/domain/domain_add.html
+++ b/app/view/domain/domain_add.html
@@ -51,6 +51,7 @@
 {block name="script"}
 <script src="/static/js/vue-2.7.16.min.js"></script>
 <script src="/static/js/layer/layer.js"></script>
+<script src="/static/js/custom.js"></script>
 <script>
 new Vue({
     el: '#app',
@@ -58,7 +59,7 @@ new Vue({
 		aid: '',
 		domainList: [],
 		page: 1,
-		pagesize: 10,
+		pagesize: getStoredPageSize('domainadd_pagesize'),
 		checkall: false,
     },
     watch: {

--- a/app/view/domain/domain_add.html
+++ b/app/view/domain/domain_add.html
@@ -51,7 +51,7 @@
 {block name="script"}
 <script src="/static/js/vue-2.7.16.min.js"></script>
 <script src="/static/js/layer/layer.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 new Vue({
     el: '#app',

--- a/app/view/domain/log.html
+++ b/app/view/domain/log.html
@@ -22,9 +22,9 @@
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'domainlog_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/record/log/{$domainId}',
@@ -41,6 +41,9 @@ $(document).ready(function(){
 				title: '操作行为'
 			}
 		],
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 </script>

--- a/app/view/domain/log.html
+++ b/app/view/domain/log.html
@@ -18,7 +18,7 @@
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/app/view/domain/qingcloud.html
+++ b/app/view/domain/qingcloud.html
@@ -229,7 +229,7 @@ td{overflow: hidden;text-overflow: ellipsis;white-space: nowrap;max-width:360px;
 <script src="/static/js/vue-2.7.16.min.js"></script>
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrapValidator.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 var recordLine = {$recordLine|json_encode|raw};
 var dnsconfig = {$dnsconfig|json_encode|raw};

--- a/app/view/domain/qingcloud.html
+++ b/app/view/domain/qingcloud.html
@@ -229,6 +229,7 @@ td{overflow: hidden;text-overflow: ellipsis;white-space: nowrap;max-width:360px;
 <script src="/static/js/vue-2.7.16.min.js"></script>
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrapValidator.min.js"></script>
+<script src="/static/js/custom.js"></script>
 <script>
 var recordLine = {$recordLine|json_encode|raw};
 var dnsconfig = {$dnsconfig|json_encode|raw};
@@ -256,7 +257,7 @@ new Vue({
       keyword: '',
       total: 0,
       offset: 0,
-      limit: 10,
+      limit: getStoredPageSize('qingcloud_pagesize'),
       parents: [],
       expandedMap: {},   // {pid: true/false}
       loadingMap: {},    // {pid: true/false}

--- a/app/view/domain/record.html
+++ b/app/view/domain/record.html
@@ -255,9 +255,9 @@ var sidePagination = dnsconfig.page ? 'client' : 'server';
 var showWeight = dnsconfig.weight;
 $(document).ready(function(){
 	updateToolbar();
-	let defaultPageSize = getCookie('record_pagesize') ? getCookie('record_pagesize') : 15;
+	const pageSizeKey = 'record_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/record/data/{$domainId}',
@@ -370,9 +370,7 @@ $(document).ready(function(){
 			},
 		],
 		onPageChange: function(number, size){
-			if(size != defaultPageSize){
-				setCookie('record_pagesize', size, 24 * 3600 * 30);
-			}
+			setStoredPageSize(pageSizeKey, size);
 		},
 	});
 

--- a/app/view/domain/record.html
+++ b/app/view/domain/record.html
@@ -246,7 +246,7 @@ td{overflow: hidden;text-overflow: ellipsis;white-space: nowrap;max-width:360px;
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
 <script src="/static/js/bootstrapValidator.min.js"></script>
-<script src="/static/js/custom.js?v=1004"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 var recordLine = {$recordLine|json_encode|raw};
 var dnsconfig = {$dnsconfig|json_encode|raw};

--- a/app/view/domain/weight.html
+++ b/app/view/domain/weight.html
@@ -76,7 +76,7 @@
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 var dnsconfig = {$dnsconfig|json_encode|raw};
 var recordLine = {$recordLine|json_encode|raw};

--- a/app/view/domain/weight.html
+++ b/app/view/domain/weight.html
@@ -85,9 +85,9 @@ var weightList = [];
 var lineList = [];
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'weight_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/record/weight/data/{$domainId}',
@@ -138,6 +138,9 @@ $(document).ready(function(){
 				}
 			},
 		],
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 function editframe(id){

--- a/app/view/optimizeip/opiplist.html
+++ b/app/view/optimizeip/opiplist.html
@@ -40,7 +40,7 @@ tbody tr>td:nth-child(2){overflow: hidden;text-overflow: ellipsis;white-space: n
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/app/view/optimizeip/opiplist.html
+++ b/app/view/optimizeip/opiplist.html
@@ -44,9 +44,9 @@ tbody tr>td:nth-child(2){overflow: hidden;text-overflow: ellipsis;white-space: n
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'opiplist_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/optimizeip/opiplist/data',
@@ -146,7 +146,10 @@ $(document).ready(function(){
 		],
 		onLoadSuccess: function(data) {
 			$('[data-toggle="tooltip"]').tooltip()
-		}
+		},
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 function setActive(id, active){

--- a/app/view/schedule/stask.html
+++ b/app/view/schedule/stask.html
@@ -45,7 +45,7 @@ tbody tr>td:nth-child(5){overflow: hidden;text-overflow: ellipsis;white-space: n
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/app/view/schedule/stask.html
+++ b/app/view/schedule/stask.html
@@ -49,9 +49,9 @@ tbody tr>td:nth-child(5){overflow: hidden;text-overflow: ellipsis;white-space: n
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'stask_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/schedule/stask/data',
@@ -153,7 +153,10 @@ $(document).ready(function(){
 		],
 		onLoadSuccess: function(data) {
 			$('[data-toggle="tooltip"]').tooltip()
-		}
+		},
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 function setActive(id, active){

--- a/app/view/user/log.html
+++ b/app/view/user/log.html
@@ -33,9 +33,9 @@
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'userlog_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/log/data',
@@ -71,6 +71,9 @@ $(document).ready(function(){
 				title: '时间'
 			}
 		],
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 </script>

--- a/app/view/user/log.html
+++ b/app/view/user/log.html
@@ -29,7 +29,7 @@
 <script src="/static/js/layer/layer.js"></script>
 <script src="/static/js/bootstrap-table-1.21.4.min.js"></script>
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/app/view/user/user.html
+++ b/app/view/user/user.html
@@ -117,9 +117,9 @@
 <script>
 $(document).ready(function(){
 	updateToolbar();
-	const defaultPageSize = 15;
+	const pageSizeKey = 'user_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
-	const pageSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : defaultPageSize;
+	const pageSize = getStoredPageSize(pageSizeKey);
 
 	$("#listTable").bootstrapTable({
 		url: '/user/data',
@@ -182,6 +182,9 @@ $(document).ready(function(){
 				}
 			},
 		],
+		onPageChange: function(number, size){
+			setStoredPageSize(pageSizeKey, size);
+		},
 	})
 })
 function addframe(){

--- a/app/view/user/user.html
+++ b/app/view/user/user.html
@@ -113,7 +113,7 @@
 <script src="/static/js/bootstrap-table-page-jump-to-1.21.4.min.js"></script>
 <script src="/static/js/select2-4.0.13.min.js"></script>
 <script src="/static/js/select2-i18n-zh-CN-4.0.13.min.js"></script>
-<script src="/static/js/custom.js"></script>
+<script src="/static/js/custom.js?v=1006"></script>
 <script>
 $(document).ready(function(){
 	updateToolbar();

--- a/public/static/js/custom.js
+++ b/public/static/js/custom.js
@@ -56,6 +56,9 @@ function updateQueryStr(obj){
 	history.replaceState({}, null, '?'+arr.join("&"));
 }
 
+var VALID_PAGE_SIZES = [10, 15, 20, 30, 50, 100, 200, 300, 500];
+var DEFAULT_PAGE_SIZE = 15;
+
 if (typeof $.fn.bootstrapTable !== "undefined") {
     $.fn.bootstrapTable.custom = {
         method: 'post',
@@ -64,8 +67,8 @@ if (typeof $.fn.bootstrapTable !== "undefined") {
         pagination: true,
         sidePagination: 'server',
         pageNumber: 1,
-        pageSize: 20,
-        pageList: [10, 15, 20, 30, 50, 100],
+        pageSize: 15,
+        pageList: VALID_PAGE_SIZES,
 		loadingFontSize: '18px',
 		toolbar: '#searchToolbar',
 		showColumns: true,
@@ -170,5 +173,27 @@ function delCookie(name)
     var cval=getCookie(name);
     if(cval!=null){
       document.cookie= name + "="+cval+";expires="+exp.toGMTString();
+    }
+}
+
+function getStoredPageSize(key) {
+    var urlSize = typeof window.$_GET['pageSize'] != 'undefined' ? parseInt(window.$_GET['pageSize']) : null;
+    if (urlSize && VALID_PAGE_SIZES.indexOf(urlSize) !== -1) {
+        return urlSize;
+    }
+    var stored = localStorage.getItem(key);
+    if (stored) {
+        var storedSize = parseInt(stored);
+        if (VALID_PAGE_SIZES.indexOf(storedSize) !== -1) {
+            return storedSize;
+        }
+    }
+    return DEFAULT_PAGE_SIZE;
+}
+
+function setStoredPageSize(key, size) {
+    var intSize = parseInt(size);
+    if (VALID_PAGE_SIZES.indexOf(intSize) !== -1) {
+        localStorage.setItem(key, intSize);
     }
 }

--- a/public/static/js/custom.js
+++ b/public/static/js/custom.js
@@ -56,9 +56,6 @@ function updateQueryStr(obj){
 	history.replaceState({}, null, '?'+arr.join("&"));
 }
 
-var VALID_PAGE_SIZES = [10, 15, 20, 30, 50, 100, 200, 300, 500];
-var DEFAULT_PAGE_SIZE = 15;
-
 if (typeof $.fn.bootstrapTable !== "undefined") {
     $.fn.bootstrapTable.custom = {
         method: 'post',


### PR DESCRIPTION
1. 所有列表统一分页大小选项 [10, 15, 20, 30, 50, 100, 200, 300, 500], 默认值 15
2. 前端所有表格页面使用 localStorage 替代 cookie 持久化用户选择的分页大小, 移除原有的 cookie 分页大小存储逻辑
3. 前端 getStoredPageSize/setStoredPageSize 对分页大小做白名单校验
4. 后端新增 validateLimit() 方法对所有 limit 参数做白名单校验
