### PR TITLE
feat: 全部列表页支持服务端列头排序

### DIFF
--- a/app/controller/Cert.php
+++ b/app/controller/Cert.php
@@ -33,13 +33,21 @@ class Cert extends BaseController
         $kw = $this->request->post('kw', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('cert_account')->where('deploy', $deploy);
         if (!empty($kw)) {
             $select->whereLike('name|remark', '%' . $kw . '%')->whereOr('id', $kw);
         }
         $total = $select->count();
-        $rows = $select->order('id', 'desc')->limit($offset, $limit)->select();
+        $allowedSort = ['id' => 'id', 'typename' => 'type', 'name' => 'name', 'remark' => 'remark', 'addtime' => 'addtime'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('id', 'desc');
+        }
+        $rows = $select->limit($offset, $limit)->select();
 
         $list = [];
         foreach ($rows as $row) {
@@ -216,6 +224,8 @@ class Cert extends BaseController
         $status = input('post.status', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('cert_order')->alias('A')->leftJoin('cert_account B', 'A.aid = B.id');
         if (!empty($id)) {
@@ -242,7 +252,13 @@ class Cert extends BaseController
             }
         }
         $total = $select->count();
-        $rows = $select->fieldRaw('A.*,B.type,B.remark aremark')->order('id', 'desc')->limit($offset, $limit)->select();
+        $allowedSort = ['id' => 'A.id', 'typename' => 'B.type', 'keytype' => 'A.keytype', 'isauto' => 'A.isauto', 'issuetime' => 'A.issuetime', 'end_day' => 'A.expiretime', 'status' => 'A.status'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('A.id', 'desc');
+        }
+        $rows = $select->fieldRaw('A.*,B.type,B.remark aremark')->limit($offset, $limit)->select();
 
         $list = [];
         foreach ($rows as $row) {
@@ -650,6 +666,8 @@ class Cert extends BaseController
         $remark = input('post.remark', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('cert_deploy')->alias('A')->leftJoin('cert_account B', 'A.aid = B.id')->leftJoin('cert_order C', 'A.oid = C.id')->leftJoin('cert_account D', 'C.aid = D.id');
         if (!empty($oid)) {
@@ -671,7 +689,13 @@ class Cert extends BaseController
             $select->where('A.remark', $remark);
         }
         $total = $select->count();
-        $rows = $select->fieldRaw('A.*,B.type,B.remark aremark,B.name aname,D.type certtype,D.id certaid')->order('id', 'desc')->limit($offset, $limit)->select();
+        $allowedSort = ['id' => 'A.id', 'typename' => 'B.type', 'remark' => 'A.remark', 'active' => 'A.active', 'lasttime' => 'A.lasttime', 'status' => 'A.status'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('A.id', 'desc');
+        }
+        $rows = $select->fieldRaw('A.*,B.type,B.remark aremark,B.name aname,D.type certtype,D.id certaid')->limit($offset, $limit)->select();
 
         $list = [];
         foreach ($rows as $row) {
@@ -862,13 +886,21 @@ class Cert extends BaseController
         $kw = $this->request->post('kw', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('cert_cname')->alias('A')->leftJoin('domain B', 'A.did = B.id');
         if (!empty($kw)) {
             $select->whereLike('A.domain', '%' . $kw . '%');
         }
         $total = $select->count();
-        $rows = $select->order('A.id', 'desc')->limit($offset, $limit)->field('A.*,B.name cnamedomain')->select();
+        $allowedSort = ['id' => 'A.id', 'domain' => 'A.domain', 'status' => 'A.status', 'addtime' => 'A.addtime'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('A.id', 'desc');
+        }
+        $rows = $select->limit($offset, $limit)->field('A.*,B.name cnamedomain')->select();
 
         $list = [];
         foreach ($rows as $row) {

--- a/app/controller/Dmonitor.php
+++ b/app/controller/Dmonitor.php
@@ -43,6 +43,8 @@ class Dmonitor extends BaseController
         $kw = input('post.kw', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('dmtask')->alias('A')->join('domain B', 'A.did = B.id');
         if (!empty($kw)) {
@@ -62,7 +64,13 @@ class Dmonitor extends BaseController
             $select->where('status', intval($status));
         }
         $total = $select->count();
-        $list = $select->order('A.id', 'desc')->limit($offset, $limit)->field('A.*,B.name domain')->select()->toArray();
+        $allowedSort = ['id' => 'A.id', 'rr' => 'A.rr', 'main_value' => 'A.main_value', 'type' => 'A.type', 'checktype' => 'A.checktype', 'frequency' => 'A.frequency', 'status' => 'A.status', 'active' => 'A.active', 'checktimestr' => 'A.checktime', 'addtimestr' => 'A.addtime', 'remark' => 'A.remark'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('A.id', 'desc');
+        }
+        $list = $select->limit($offset, $limit)->field('A.*,B.name domain')->select()->toArray();
 
         foreach ($list as &$row) {
             $row['addtimestr'] = date('Y-m-d H:i:s', $row['addtime']);
@@ -234,13 +242,21 @@ class Dmonitor extends BaseController
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
         $action = input('post.action/d', 0);
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('dmlog')->where('taskid', $taskid);
         if ($action > 0) {
             $select->where('action', $action);
         }
         $total = $select->count();
-        $list = $select->order('id', 'desc')->limit($offset, $limit)->select();
+        $allowedSort = ['id' => 'id', 'action' => 'action', 'date' => 'date', 'errmsg' => 'errmsg'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('id', 'desc');
+        }
+        $list = $select->limit($offset, $limit)->select();
 
         return json(['total' => $total, 'rows' => $list]);
     }

--- a/app/controller/Domain.php
+++ b/app/controller/Domain.php
@@ -26,13 +26,21 @@ class Domain extends BaseController
         $kw = $this->request->post('kw', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('account');
         if (!empty($kw)) {
             $select->whereLike('name|remark', '%' . $kw . '%');
         }
         $total = $select->count();
-        $rows = $select->order('id', 'desc')->limit($offset, $limit)->select();
+        $allowedSort = ['id' => 'id', 'typename' => 'type', 'name' => 'name', 'remark' => 'remark', 'addtime' => 'addtime'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('id', 'desc');
+        }
+        $rows = $select->limit($offset, $limit)->select();
 
         $list = [];
         foreach ($rows as $row) {
@@ -192,7 +200,8 @@ class Domain extends BaseController
         $type = input('post.type', null, 'trim');
         $status = input('post.status', null, 'trim');
         $cid = input('post.cid', null, 'trim');
-        $order = input('post.order', null, 'trim');
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
         $offset = input('post.offset/d', 0);
         $limit = input('post.limit/d', 10);
         $id = input('post.id');
@@ -224,21 +233,11 @@ class Domain extends BaseController
             }
         }
         $total = $select->count();
-        switch ($order) {
-            case '1':
-                $select->order('A.regtime', 'asc');
-                break;
-            case '2':
-                $select->order('A.regtime', 'desc');
-                break;
-            case '3':
-                $select->order('A.expiretime', 'asc');
-                break;
-            case '4':
-                $select->order('A.expiretime', 'desc');
-                break;
-            default:
-                $select->order('A.id', 'desc');
+        $allowedSort = ['id' => 'A.id', 'name' => 'A.name', 'recordcount' => 'A.recordcount', 'addtime' => 'A.addtime', 'regtime' => 'A.regtime', 'expiretime' => 'A.expiretime', 'is_notice' => 'A.is_notice', 'is_hide' => 'A.is_hide', 'is_sso' => 'A.is_sso', 'typename' => 'B.type', 'category_name' => 'A.cid', 'remark' => 'A.remark'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('A.id', 'desc');
         }
         $rows = $select->fieldRaw('A.*,B.type,B.remark aremark')->limit($offset, $limit)->select();
 
@@ -1392,10 +1391,18 @@ class Domain extends BaseController
         if (!checkPermission(2)) return json(['total' => 0, 'rows' => []]);
         $offset = input('post.offset/d', 0);
         $limit = input('post.limit/d', 10);
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('domain_category');
         $total = $select->count();
-        $rows = $select->order('sort', 'asc')->order('id', 'desc')->limit($offset, $limit)->select()->toArray();
+        $allowedSort = ['id' => 'id', 'name' => 'name', 'remark' => 'remark', 'sort' => 'sort', 'addtime' => 'addtime'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('id', 'desc');
+        }
+        $rows = $select->limit($offset, $limit)->select()->toArray();
 
         foreach ($rows as &$row) {
             $row['domain_count'] = Db::name('domain')->where('cid', $row['id'])->count();

--- a/app/controller/Optimizeip.php
+++ b/app/controller/Optimizeip.php
@@ -45,6 +45,8 @@ class Optimizeip extends BaseController
         $status = input('post.status', null);
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('optimizeip')->alias('A')->join('domain B', 'A.did = B.id');
         if (!empty($kw)) {
@@ -58,7 +60,13 @@ class Optimizeip extends BaseController
             $select->where('status', intval($status));
         }
         $total = $select->count();
-        $list = $select->order('A.id', 'desc')->limit($offset, $limit)->field('A.*,B.name domain')->select();
+        $allowedSort = ['id' => 'A.id', 'rr' => 'A.rr', 'cdn_type' => 'A.cdn_type', 'recordnum' => 'A.recordnum', 'ip_type' => 'A.ip_type', 'active' => 'A.active', 'updatetime' => 'A.updatetime', 'status' => 'A.status'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('A.id', 'desc');
+        }
+        $list = $select->limit($offset, $limit)->field('A.*,B.name domain')->select();
 
         return json(['total' => $total, 'rows' => $list]);
     }

--- a/app/controller/Schedule.php
+++ b/app/controller/Schedule.php
@@ -24,6 +24,8 @@ class Schedule extends BaseController
         $stype = input('post.stype', null);
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('sctask')->alias('A')->join('domain B', 'A.did = B.id');
         if (!empty($kw)) {
@@ -41,7 +43,13 @@ class Schedule extends BaseController
             $select->where('type', $stype);
         }
         $total = $select->count();
-        $list = $select->order('A.id', 'desc')->limit($offset, $limit)->field('A.*,B.name domain')->select()->toArray();
+        $allowedSort = ['id' => 'A.id', 'rr' => 'A.rr', 'type' => 'A.type', 'switchtype' => 'A.switchtype', 'active' => 'A.active', 'updatetimestr' => 'A.updatetime', 'nexttimestr' => 'A.nexttime', 'addtimestr' => 'A.addtime', 'remark' => 'A.remark'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('A.id', 'desc');
+        }
+        $list = $select->limit($offset, $limit)->field('A.*,B.name domain')->select()->toArray();
 
         foreach ($list as &$row) {
             $row['addtimestr'] = date('Y-m-d H:i:s', $row['addtime']);

--- a/app/controller/User.php
+++ b/app/controller/User.php
@@ -28,13 +28,21 @@ class User extends BaseController
         $kw = input('post.kw', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('user');
         if (!empty($kw)) {
             $select->whereLike('id|username', $kw);
         }
         $total = $select->count();
-        $rows = $select->order('id', 'desc')->limit($offset, $limit)->select();
+        $allowedSort = ['id' => 'id', 'username' => 'username', 'level' => 'level', 'is_api' => 'is_api', 'regtime' => 'regtime', 'lasttime' => 'lasttime', 'status' => 'status'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('id', 'desc');
+        }
+        $rows = $select->limit($offset, $limit)->select();
 
         return json(['total' => $total, 'rows' => $rows]);
     }
@@ -165,6 +173,8 @@ class User extends BaseController
         $domain = input('post.domain', null, 'trim');
         $offset = input('post.offset/d');
         $limit = input('post.limit/d');
+        $sort = input('post.sortName', null, 'trim');
+        $orderDir = strtolower(input('post.sortOrder', 'desc')) === 'asc' ? 'asc' : 'desc';
 
         $select = Db::name('log');
         if ($this->request->user['type'] == 'domain') {
@@ -181,7 +191,13 @@ class User extends BaseController
             $select->where('domain', $domain);
         }
         $total = $select->count();
-        $rows = $select->order('id', 'desc')->limit($offset, $limit)->select();
+        $allowedSort = ['id' => 'id', 'uid' => 'uid', 'domain' => 'domain', 'action' => 'action', 'data' => 'data', 'addtime' => 'addtime'];
+        if ($sort && isset($allowedSort[$sort])) {
+            $select->order($allowedSort[$sort], $orderDir);
+        } else {
+            $select->order('id', 'desc');
+        }
+        $rows = $select->limit($offset, $limit)->select();
 
         return json(['total' => $total, 'rows' => $rows]);
     }

--- a/app/view/cert/certaccount.html
+++ b/app/view/cert/certaccount.html
@@ -34,35 +34,70 @@ $(document).ready(function(){
 	const pageSizeKey = 'certaccount_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/cert/account/data?deploy=0',
 		pageNumber: pageNumber,
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'typename',
 				title: '所属平台',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return '<img src="/static/images/'+row.icon+'" class="type-logo"></img>'+value;
 				}
 			},
 			{
 				field: 'name',
-				title: '账户名称'
+				title: '账户名称',
+				sortable: true
 			},
 			{
 				field: 'remark',
-				title: '备注'
+				title: '备注',
+				sortable: true
 			},
 			{
 				field: 'addtime',
-				title: '添加时间'
+				title: '添加时间',
+				sortable: true
 			},
 			{
 				field: 'action',

--- a/app/view/cert/certorder.html
+++ b/app/view/cert/certorder.html
@@ -62,6 +62,8 @@ $(document).ready(function(){
 	const pageSizeKey = 'certorder_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey, 10);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/cert/order/data',
@@ -69,6 +71,34 @@ $(document).ready(function(){
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
 		uniqueId: 'id',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: '',
@@ -76,14 +106,16 @@ $(document).ready(function(){
 			},
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'typename',
 				title: '证书账户',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value){
-						return '<span title="'+row.aremark+'" data-toggle="tooltip" data-placement="right"><img src="/static/images/'+row.icon+'" class="type-logo">'+value+'('+row.aid+')</span>';
+				return '<span title="'+row.aremark+'" data-toggle="tooltip" data-placement="right"><img src="/static/images/'+row.icon+'" class="type-logo">'+value+'('+row.aid+')</span>';
 					}
 					return '手动续期';
 				}
@@ -98,6 +130,7 @@ $(document).ready(function(){
 			{
 				field: 'keytype',
 				title: '证书信息',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return '<span class="text-muted">签名算法:</span>'+row.keytype+'('+row.keysize+')'+(row.issuer?'<br/><span class="text-muted">颁发机构:</span>'+row.issuer:'');
 				}
@@ -105,17 +138,19 @@ $(document).ready(function(){
 			{
 				field: 'isauto',
 				title: '自动续签',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 1){
-						return '<div class="material-switch"><input id="isauto'+row.id+'" type="checkbox" checked onchange="setAuto('+row.id+',0)"/><label for="isauto'+row.id+'" class="label-primary"></label></div>';
+				return '<div class="material-switch"><input id="isauto'+row.id+'" type="checkbox" checked onchange="setAuto('+row.id+',0)"/><label for="isauto'+row.id+'" class="label-primary"></label></div>';
 					}else{
-						return '<div class="material-switch"><input id="isauto'+row.id+'" type="checkbox" onchange="setAuto('+row.id+',1)"/><label for="isauto'+row.id+'" class="label-primary"></label></div>';
+				return '<div class="material-switch"><input id="isauto'+row.id+'" type="checkbox" onchange="setAuto('+row.id+',1)"/><label for="isauto'+row.id+'" class="label-primary"></label></div>';
 					}
 				}
 			},
 			{
 				field: 'issuetime',
 				title: '签发时间',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return value ? value.substring(0,10) : '暂未签发';
 				}
@@ -123,6 +158,7 @@ $(document).ready(function(){
 			{
 				field: 'end_day',
 				title: '到期时间',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value != null){
 						if(value > 7){
@@ -133,18 +169,19 @@ $(document).ready(function(){
 							return '<span title="'+row.expiretime+'" data-toggle="tooltip" data-placement="right" style="color:red">已过期<span>';
 						}
 					}else{
-						return '暂未签发';
+				return '暂未签发';
 					}
 				}
 			},
 			{
 				field: 'status',
 				title: '状态',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 4) {
-						return '<span class="label" style="background-color: #a5a5a5;">已吊销</span>';
+				return '<span class="label" style="background-color: #a5a5a5;">已吊销</span>';
 					} else if(value == 3) {
-						return '<span class="label label-success">已签发</span>';
+				return '<span class="label label-success">已签发</span>';
 					} else if(value == 2) {
 						if(row.retrytime != null){
 							var now = new Date().getTime();
@@ -156,7 +193,7 @@ $(document).ready(function(){
 								return '<span title="'+min+'分'+sec+'秒后自动验证" data-toggle="tooltip" data-placement="top" class="label" style="background-color: #3e76fb;">正在验证</span>';
 							}
 						}
-						return '<span class="label" style="background-color: #3e76fb;">正在验证</span>';
+				return '<span class="label" style="background-color: #3e76fb;">正在验证</span>';
 					} else if(value == 1) {
 						if(row.retrytime != null){
 							var now = new Date().getTime();
@@ -168,9 +205,9 @@ $(document).ready(function(){
 								return '<span title="'+min+'分'+sec+'秒后自动验证" data-toggle="tooltip" data-placement="top" class="label" style="background-color: #3e76fb;">待验证</span>';
 							}
 						}
-						return '<span class="label" style="background-color: #3e76fb;">待验证</span>';
+				return '<span class="label" style="background-color: #3e76fb;">待验证</span>';
 					} else if(value == 0) {
-						return '<span class="label label-info">待提交</span>';
+				return '<span class="label label-info">待提交</span>';
 					} else {
 						var title = '失败';
 						if(value == -1) title = '购买证书失败';
@@ -190,7 +227,7 @@ $(document).ready(function(){
 								return '<span title="'+min+'分'+sec+'秒后自动重试" data-toggle="tooltip" data-placement="top" class="label label-danger">'+title+'</span>'+(row.error?' <span onclick="showmsg(\''+row.error+'\')" class="tips" title="失败原因"><i class="fa fa-info-circle"></i></span>':'');
 							}
 						}
-						return '<span class="label label-danger">'+title+'</span>'+(row.error?' <span onclick="showmsg(\''+row.error+'\')" class="tips" title="失败原因"><i class="fa fa-info-circle"></i></span>':'');
+				return '<span class="label label-danger">'+title+'</span>'+(row.error?' <span onclick="showmsg(\''+row.error+'\')" class="tips" title="失败原因"><i class="fa fa-info-circle"></i></span>':'');
 					}
 				}
 			},

--- a/app/view/cert/cname.html
+++ b/app/view/cert/cname.html
@@ -81,6 +81,8 @@ $(document).ready(function(){
 	const pageSizeKey = 'cname_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/cert/cname/data',
@@ -88,14 +90,44 @@ $(document).ready(function(){
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
 		uniqueId: 'id',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'domain',
-				title: '被代理域名'
+				title: '被代理域名',
+				sortable: true
 			},
 			{
 				field: 'host',
@@ -114,6 +146,7 @@ $(document).ready(function(){
 			{
 				field: 'status',
 				title: '状态',
+				sortable: true,
 				formatter: function(value, row, index) {
 					var html = '';
 					if(value == 1) {
@@ -127,7 +160,8 @@ $(document).ready(function(){
 			},
 			{
 				field: 'addtime',
-				title: '添加时间'
+				title: '添加时间',
+				sortable: true
 			},
 			{
 				field: 'action',

--- a/app/view/cert/deployaccount.html
+++ b/app/view/cert/deployaccount.html
@@ -34,35 +34,70 @@ $(document).ready(function(){
 	const pageSizeKey = 'deployaccount_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/cert/account/data?deploy=1',
 		pageNumber: pageNumber,
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'typename',
 				title: '账户类型',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return '<img src="/static/images/'+row.icon+'" class="type-logo"></img>'+value;
 				}
 			},
 			{
 				field: 'name',
-				title: '账户名称'
+				title: '账户名称',
+				sortable: true
 			},
 			{
 				field: 'remark',
-				title: '备注'
+				title: '备注',
+				sortable: true
 			},
 			{
 				field: 'addtime',
-				title: '添加时间'
+				title: '添加时间',
+				sortable: true
 			},
 			{
 				field: 'action',

--- a/app/view/cert/deploytask.html
+++ b/app/view/cert/deploytask.html
@@ -61,6 +61,8 @@ $(document).ready(function(){
 	const pageSizeKey = 'deploytask_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey, 10);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/cert/deploy/data',
@@ -68,6 +70,34 @@ $(document).ready(function(){
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
 		uniqueId: 'id',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: '',
@@ -75,11 +105,13 @@ $(document).ready(function(){
 			},
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'typename',
 				title: '自动部署账户',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(!value) return '已被删除'
 					return '<span title="'+row.aname+'" data-toggle="tooltip" data-placement="right"><img src="/static/images/'+row.icon+'" class="type-logo">'+(row.aremark?row.aremark:value+'('+row.aid+')')+'</span>';
@@ -97,22 +129,25 @@ $(document).ready(function(){
 			},
 			{
 				field: 'remark',
-				title: '备注'
+				title: '备注',
+				sortable: true
 			},
 			{
 				field: 'active',
 				title: '任务开关',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 1){
-						return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" checked onchange="setActive('+row.id+',0)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
+				return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" checked onchange="setActive('+row.id+',0)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
 					}else{
-						return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" onchange="setActive('+row.id+',1)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
+				return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" onchange="setActive('+row.id+',1)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
 					}
 				}
 			},
 			{
 				field: 'lasttime',
 				title: '上次执行时间',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return value ? value : '暂未执行'
 				}
@@ -120,14 +155,15 @@ $(document).ready(function(){
 			{
 				field: 'status',
 				title: '状态',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 1) {
-						return '<span class="label label-success">已完成</span>';
+				return '<span class="label label-success">已完成</span>';
 					} else if(value == 0) {
 						if(row.islock == 1) return '<span class="label" style="background-color: #3e76fb;">正在处理</span>';
 						else return '<span class="label label-info">待处理</span>';
 					} else {
-						return '<span class="label label-danger">处理失败</span>'+(row.error?' <span onclick="showmsg(\''+row.error+'\')" class="tips" title="失败原因"><i class="fa fa-info-circle"></i></span>':'');
+				return '<span class="label label-danger">处理失败</span>'+(row.error?' <span onclick="showmsg(\''+row.error+'\')" class="tips" title="失败原因"><i class="fa fa-info-circle"></i></span>':'');
 					}
 				}
 			},

--- a/app/view/dmonitor/task.html
+++ b/app/view/dmonitor/task.html
@@ -52,12 +52,42 @@ $(document).ready(function(){
 	const pageSizeKey = 'dmtask_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/dmonitor/task/data',
 		pageNumber: pageNumber,
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: '',
@@ -65,11 +95,13 @@ $(document).ready(function(){
 			},
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'rr',
 				title: '域名',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return '<span title="'+row.remark+'" data-toggle="tooltip" data-placement="right">' + value + '.' + row.domain + '</span>';
 				}
@@ -77,6 +109,7 @@ $(document).ready(function(){
 			{
 				field: 'main_value',
 				title: '解析记录',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return value;
 				}
@@ -84,21 +117,23 @@ $(document).ready(function(){
 			{
 				field: 'type',
 				title: '切换设置',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 1) {
-						return '暂停解析';
+				return '暂停解析';
 					} else if(value == 2) {
-						return '<span title="" data-toggle="tooltip" data-placement="bottom" data-original-title="备用：'+row.backup_value+'" class="tips">切换备用</span>';
+				return '<span title="" data-toggle="tooltip" data-placement="bottom" data-original-title="备用：'+row.backup_value+'" class="tips">切换备用</span>';
 					} else if(value == 3) {
-						return '<span title="" data-toggle="tooltip" data-placement="bottom" data-original-title="同域名正常数量<='+row.cycle+'" class="tips">条件开启</span>';
+				return '<span title="" data-toggle="tooltip" data-placement="bottom" data-original-title="同域名正常数量<='+row.cycle+'" class="tips">条件开启</span>';
 					} else {
-						return '无操作';
+				return '无操作';
 					}
 				}
 			},
 			{
 				field: 'checktype',
 				title: '检测协议',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(row.type <= 2){
 						if(value == 1) {
@@ -109,13 +144,14 @@ $(document).ready(function(){
 							return 'PING';
 						}
 					} else {
-						return '无';
+				return '无';
 					}
 				}
 			},
 			{
 				field: 'frequency',
 				title: '检测间隔',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return value + '秒';
 				}
@@ -123,37 +159,42 @@ $(document).ready(function(){
 			{
 				field: 'status',
 				title: '健康状况',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 0) {
-						return '<span class="label label-success">正常</span>';
+				return '<span class="label label-success">正常</span>';
 					} else {
-						return '<span class="label label-danger">异常</span>';
+				return '<span class="label label-danger">异常</span>';
 					}
 				}
 			},
 			{
 				field: 'active',
 				title: '运行开关',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 1){
-						return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" checked onchange="setActive('+row.id+',0)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
+				return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" checked onchange="setActive('+row.id+',0)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
 					}else{
-						return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" onchange="setActive('+row.id+',1)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
+				return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" onchange="setActive('+row.id+',1)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
 					}
 				}
 			},
 			{
 				field: 'checktimestr',
-				title: '上次检测时间'
+				title: '上次检测时间',
+				sortable: true
 			},
 			{
 				field: 'addtimestr',
 				title: '添加时间',
+				sortable: true,
 				visible: false
 			},
 			{
 				field: 'remark',
 				title: '备注',
+				sortable: true,
 				visible: false
 			},
 			{

--- a/app/view/dmonitor/taskinfo.html
+++ b/app/view/dmonitor/taskinfo.html
@@ -40,31 +40,65 @@ $(document).ready(function(){
 	const pageSizeKey = 'dmtaskinfo_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/dmonitor/task/log/data/{$info.id}',
 		pageNumber: pageNumber,
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'action',
 				title: '操作类型',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return action_name[value];
 				}
 			},
 			{
 				field: 'date',
-				title: '时间'
+				title: '时间',
+				sortable: true
 			},
 			{
 				field: 'errmsg',
-				title: '异常原因'
+				title: '异常原因',
+				sortable: true
 			}
 		],
 		onPageChange: function(number, size){

--- a/app/view/domain/account.html
+++ b/app/view/domain/account.html
@@ -35,35 +35,70 @@ $(document).ready(function(){
 	const pageSizeKey = 'account_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/account/data',
 		pageNumber: pageNumber,
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'typename',
 				title: '所属平台',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return '<img src="/static/images/'+row.icon+'" class="type-logo"></img>'+value;
 				}
 			},
             {
 				field: 'name',
-				title: '账户名称'
+				title: '账户名称',
+				sortable: true
 			},
 			{
 				field: 'remark',
-				title: '备注'
+				title: '备注',
+				sortable: true
 			},
 			{
 				field: 'addtime',
-				title: '添加时间'
+				title: '添加时间',
+				sortable: true
 			},
 			{
 				field: 'action',

--- a/app/view/domain/category.html
+++ b/app/view/domain/category.html
@@ -68,6 +68,8 @@ $(document).ready(function(){
 	const pageSizeKey = 'category_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/domain/category/data',
@@ -75,25 +77,57 @@ $(document).ready(function(){
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
 		uniqueId: 'id',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'name',
-				title: '分类名称'
+				title: '分类名称',
+				sortable: true
 			},
 			{
 				field: 'remark',
 				title: '备注',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return value ? value : '-';
 				}
 			},
 			{
 				field: 'sort',
-				title: '排序'
+				title: '排序',
+				sortable: true
 			},
 			{
 				field: 'domain_count',
@@ -104,7 +138,8 @@ $(document).ready(function(){
 			},
 			{
 				field: 'addtime',
-				title: '添加时间'
+				title: '添加时间',
+				sortable: true
 			},
 			{
 				field: 'action',

--- a/app/view/domain/domain.html
+++ b/app/view/domain/domain.html
@@ -155,9 +155,6 @@
   <div class="form-group">
 	<select name="status" class="form-control"><option value="">所有状态</option><option value="1">即将到期</option><option value="2">已到期</option></select>
   </div>
-  <div class="form-group">
-	<select name="order" class="form-control"><option value="">默认排序</option><option value="1">注册时间↑</option><option value="2">注册时间↓</option><option value="3">到期时间↑</option><option value="4">到期时间↓</option></select>
-  </div>
   <button type="submit" class="btn btn-primary"><i class="fa fa-search"></i> 搜索</button>
   <a href="javascript:searchClear()" class="btn btn-default" title="刷新域名列表"><i class="fa fa-refresh"></i> 刷新</a>
   {if $user['level'] eq 2}<a href="javascript:addframe()" class="btn btn-success"><i class="fa fa-plus"></i> 添加</a>
@@ -192,6 +189,8 @@ $(document).ready(function(){
 	const pageSizeKey = 'domain_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/domain/data',
@@ -199,6 +198,34 @@ $(document).ready(function(){
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
 		uniqueId: 'id',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: '',
@@ -206,11 +233,13 @@ $(document).ready(function(){
 			},
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'typename',
 				title: '平台账户',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return '<img src="/static/images/'+row.icon+'" class="type-logo"></img>'+(row.aremark?row.aremark:value+'('+row.aid+')');
 				}
@@ -218,21 +247,25 @@ $(document).ready(function(){
             {
 				field: 'name',
 				title: '域名',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return '<a href="/record/'+row.id+'" title="进入解析记录管理" onclick="loading()">'+value+'</a>';
 				}
 			},
 			{
 				field: 'recordcount',
-				title: '记录数'
+				title: '记录数',
+				sortable: true
 			},
 			{
 				field: 'addtime',
-				title: '添加时间'
+				title: '添加时间',
+				sortable: true
 			},
 			{
 				field: 'regtime',
 				title: '注册时间',
+				sortable: true,
 				visible: false,
 				formatter: function(value, row, index) {
 					var html = '';
@@ -251,6 +284,7 @@ $(document).ready(function(){
 			{
 				field: 'expiretime',
 				title: '到期时间',
+				sortable: true,
 				formatter: function(value, row, index) {
 					var html = '';
 					if(value == null) {
@@ -278,6 +312,7 @@ $(document).ready(function(){
 			{
 				field: 'is_notice',
 				title: '到期提醒',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return value==1?'<font color="green">是</font>':'<font color="blue">否</font>';
 				}
@@ -285,6 +320,7 @@ $(document).ready(function(){
 			{
 				field: 'is_hide',
 				title: '是否隐藏',
+				sortable: true,
 				visible: false,
 				formatter: function(value, row, index) {
 					return value==1?'<font color="grey">是</font>':'<font color="blue">否</font>';
@@ -293,6 +329,7 @@ $(document).ready(function(){
 			{
 				field: 'is_sso',
 				title: '对接开关',
+				sortable: true,
 				visible: false,
 				formatter: function(value, row, index) {
 					return value==1?'<font color="green">是</font>':'<font color="red">否</font>';
@@ -301,13 +338,15 @@ $(document).ready(function(){
 			{
 				field: 'category_name',
 				title: '分类',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return value ? '<span class="label label-default">' + value + '</span>' : '-';
 				}
 			},
 			{
 				field: 'remark',
-				title: '备注'
+				title: '备注',
+				sortable: true
 			},
 			{
 				field: 'action',

--- a/app/view/optimizeip/opiplist.html
+++ b/app/view/optimizeip/opiplist.html
@@ -47,20 +47,52 @@ $(document).ready(function(){
 	const pageSizeKey = 'opiplist_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/optimizeip/opiplist/data',
 		pageNumber: pageNumber,
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'rr',
 				title: '域名',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return '<span title="'+row.remark+'" data-toggle="tooltip" data-placement="right">' + value + '.' + row.domain + '</span>';
 				}
@@ -68,23 +100,25 @@ $(document).ready(function(){
 			{
 				field: 'cdn_type',
 				title: 'CDN运营商',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 1){
-						return 'CloudFlare';
+				return 'CloudFlare';
 					}else if(value == 2){
-						return 'CloudFront';
+				return 'CloudFront';
 					}else if(value == 3){
-						return 'Gcore';
+				return 'Gcore';
 					}else if(value == 4){
-						return 'EdgeOne';
+				return 'EdgeOne';
 					}else{
-						return '未知';
+				return '未知';
 					}
 				}
 			},
 			{
 				field: 'recordnum',
 				title: '解析数量',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return '<span title="" data-toggle="tooltip" data-placement="bottom" data-original-title="TTL：'+row.ttl+'" class="tips">'+value+'</span>';
 				}
@@ -92,6 +126,7 @@ $(document).ready(function(){
 			{
 				field: 'ip_type',
 				title: '解析IP类型',
+				sortable: true,
 				formatter: function(value, row, index) {
 					var value = value.split(',')
 					value.forEach((element, index) => {
@@ -104,17 +139,19 @@ $(document).ready(function(){
 			{
 				field: 'active',
 				title: '任务开关',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 1){
-						return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" checked onchange="setActive('+row.id+',0)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
+				return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" checked onchange="setActive('+row.id+',0)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
 					}else{
-						return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" onchange="setActive('+row.id+',1)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
+				return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" onchange="setActive('+row.id+',1)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
 					}
 				}
 			},
 			{
 				field: 'updatetime',
 				title: '上次更新时间',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return value ? value : '无';
 				}
@@ -122,13 +159,14 @@ $(document).ready(function(){
 			{
 				field: 'status',
 				title: '上次更新结果',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 1) {
-						return '<span class="label label-success">成功</span>';
+				return '<span class="label label-success">成功</span>';
 					} else if(value == 2) {
-						return '<span class="label label-danger">失败</span> <span title="" data-toggle="tooltip" data-placement="bottom" data-original-title="'+row.errmsg+'" class="tips"><i class="fa fa-info-circle"></i></span>';
+				return '<span class="label label-danger">失败</span> <span title="" data-toggle="tooltip" data-placement="bottom" data-original-title="'+row.errmsg+'" class="tips"><i class="fa fa-info-circle"></i></span>';
 					} else {
-						return '<span class="label label-warning">未运行</span>';
+				return '<span class="label label-warning">未运行</span>';
 					}
 				}
 			},

--- a/app/view/schedule/stask.html
+++ b/app/view/schedule/stask.html
@@ -52,12 +52,42 @@ $(document).ready(function(){
 	const pageSizeKey = 'stask_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/schedule/stask/data',
 		pageNumber: pageNumber,
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: '',
@@ -65,11 +95,13 @@ $(document).ready(function(){
 			},
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'rr',
 				title: '域名',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return '<span title="'+row.remark+'" data-toggle="tooltip" data-placement="right">' + value + '.' + row.domain + '</span>';
 				}
@@ -77,6 +109,7 @@ $(document).ready(function(){
 			{
 				field: 'type',
 				title: '时间设置',
+				sortable: true,
 				formatter: function(value, row, index) {
                     if(value == 1){
                         var text = '<span class="label bg-purple">周期执行</span> ';
@@ -97,46 +130,52 @@ $(document).ready(function(){
 			{
 				field: 'switchtype',
 				title: '切换设置',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 1) {
-						return '启用解析';
+				return '启用解析';
 					} else if(value == 2) {
-						return '暂停解析';
+				return '暂停解析';
 					} else if(value == 3) {
-						return '删除解析';
+				return '删除解析';
 					} else {
-						return '修改解析['+row.value+']';
+				return '修改解析['+row.value+']';
 					}
 				}
 			},
 			{
 				field: 'active',
 				title: '运行开关',
+				sortable: true,
 				formatter: function(value, row, index) {
 					if(value == 1){
-						return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" checked onchange="setActive('+row.id+',0)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
+				return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" checked onchange="setActive('+row.id+',0)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
 					}else{
-						return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" onchange="setActive('+row.id+',1)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
+				return '<div class="material-switch"><input id="active'+row.id+'" type="checkbox" onchange="setActive('+row.id+',1)"/><label for="active'+row.id+'" class="label-primary"></label></div>';
 					}
 				}
 			},
 			{
 				field: 'updatetimestr',
-				title: '上次切换时间'
+				title: '上次切换时间',
+				sortable: true
 			},
             {
 				field: 'nexttimestr',
 				title: '下次切换时间',
+				sortable: true,
 				visible: false
 			},
 			{
 				field: 'addtimestr',
 				title: '添加时间',
+				sortable: true,
 				visible: false
 			},
 			{
 				field: 'remark',
-				title: '备注'
+				title: '备注',
+				sortable: true
 			},
 			{
 				field: 'action',

--- a/app/view/user/log.html
+++ b/app/view/user/log.html
@@ -36,39 +36,75 @@ $(document).ready(function(){
 	const pageSizeKey = 'userlog_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/log/data',
 		pageNumber: pageNumber,
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: 'id',
-				title: 'ID'
+				title: 'ID',
+				sortable: true
 			},
 			{
 				field: 'uid',
 				title: 'UID',
+				sortable: true,
 				formatter: function(value, row, index) {
 					return value>0?'<a href="/user?kw='+value+'" target="_blank">'+value+'</a>':'管理员';
 				}
 			},
 			{
 				field: 'domain',
-				title: '域名'
+				title: '域名',
+				sortable: true
 			},
 			{
 				field: 'action',
-				title: '操作类型'
+				title: '操作类型',
+				sortable: true
 			},
             {
 				field: 'data',
-				title: '操作详情'
+				title: '操作详情',
+				sortable: true
 			},
 			{
 				field: 'addtime',
-				title: '时间'
+				title: '时间',
+				sortable: true
 			}
 		],
 		onPageChange: function(number, size){

--- a/app/view/user/user.html
+++ b/app/view/user/user.html
@@ -120,24 +120,57 @@ $(document).ready(function(){
 	const pageSizeKey = 'user_pagesize';
 	const pageNumber = typeof window.$_GET['pageNumber'] != 'undefined' ? parseInt(window.$_GET['pageNumber']) : 1;
 	const pageSize = getStoredPageSize(pageSizeKey);
+	var urlSort = typeof window.$_GET['sortName'] != 'undefined' ? window.$_GET['sortName'] : undefined;
+	var urlOrder = typeof window.$_GET['sortOrder'] != 'undefined' ? window.$_GET['sortOrder'] : undefined;
 
 	$("#listTable").bootstrapTable({
 		url: '/user/data',
 		pageNumber: pageNumber,
 		pageSize: pageSize,
 		classes: 'table table-striped table-hover table-bordered',
+		sortReset: false,
+		sortName: urlSort,
+		sortOrder: urlOrder,
+		onSort: function(name, order) {
+			var $table = $('#listTable');
+			if (!name) {
+				$table.data('_sortClicks', null);
+				return;
+			}
+			var clicks = $table.data('_sortClicks') || {};
+			if (clicks._last !== name) {
+				clicks = {_last: name};
+				clicks[name] = 1;
+				this.sortOrder = 'desc';
+			} else {
+				clicks[name] = (clicks[name] || 0) + 1;
+				if (clicks[name] === 1) {
+					this.sortOrder = 'desc';
+				} else if (clicks[name] === 2) {
+					this.sortOrder = 'asc';
+				} else {
+					this.sortName = undefined;
+					this.sortOrder = undefined;
+					clicks = {};
+				}
+			}
+			$table.data('_sortClicks', clicks);
+		},
 		columns: [
 			{
 				field: 'id',
-				title: 'UID'
+				title: 'UID',
+				sortable: true
 			},
 			{
 				field: 'username',
-				title: '用户名'
+				title: '用户名',
+				sortable: true
 			},
 			{
 				field: 'level',
 				title: '用户等级',
+				sortable: true,
 				formatter: function(value, row, index) {
 					switch(value){
 						case 1: return '<font color="blue">普通用户</font>';break;
@@ -148,6 +181,7 @@ $(document).ready(function(){
             {
 				field: 'is_api',
 				title: 'API接口',
+				sortable: true,
 				formatter: function(value, row, index) {
 					switch(value){
 						case 0: return '<font color="grey">关闭</font>';break;
@@ -157,15 +191,18 @@ $(document).ready(function(){
 			},
 			{
 				field: 'regtime',
-				title: '添加时间'
+				title: '添加时间',
+				sortable: true
 			},
 			{
 				field: 'lasttime',
-				title: '上次登录时间'
+				title: '上次登录时间',
+				sortable: true
 			},
 			{
 				field: 'status',
 				title: '状态',
+				sortable: true,
 				formatter: function(value, row, index) {
 					switch(value){
 						case 0: return '<a href="javascript:setStatus('+row.id+',1)"><font color=red><i class="fa fa-times-circle"></i>封禁</font></a>';break;


### PR DESCRIPTION
## 概述

为全部 14 个服务端分页列表页添加列头点击排序功能，利用 Bootstrap Table 原生排序机制，
通过 `onSort` 回调实现三态循环排序交互。

## 排序交互

点击列头三态循环：**默认(ID降序) → 该列降序 → 该列升序 → 恢复默认**

排序参数通过 URL 传递（`?sortName=字段&sortOrder=asc|desc`），支持分享排序后的列表链接。

## 涉及页面（14 个）

| 模块 | 页面 | 可排序字段 |
|------|------|-----------|
| 域名管理 | 域名列表 | ID, 平台账户, 域名, 记录数, 添加时间, 注册时间, 到期时间, 到期提醒, 是否隐藏, 对接开关, 分类, 备注 |
| 域名管理 | 平台账户 | ID, 所属平台, 账户名称, 备注, 添加时间 |
| 域名管理 | 域名分类 | ID, 分类名称, 备注, 排序值, 添加时间 |
| SSL证书 | 证书账户 | ID, 所属平台, 账户名称, 备注, 添加时间 |
| SSL证书 | 订单列表 | ID, 证书账户, 证书信息, 自动续签, 签发时间, 到期时间, 状态 |
| SSL证书 | CNAME代理 | ID, 被代理域名, 状态, 添加时间 |
| SSL证书 | 部署账户 | ID, 账户类型, 账户名称, 备注, 添加时间 |
| SSL证书 | 部署任务 | ID, 部署账户, 备注, 任务开关, 上次执行时间, 状态 |
| 容灾切换 | 切换策略 | ID, 域名, 解析记录, 切换设置, 检测协议, 检测间隔, 健康状况, 运行开关, 上次检测时间, 添加时间, 备注 |
| 容灾切换 | 切换日志 | ID, 操作类型, 时间, 异常原因 |
| 用户管理 | 用户列表 | ID, 用户名, 用户等级, API接口, 添加时间, 上次登录, 状态 |
| 用户管理 | 操作日志 | ID, UID, 域名, 操作类型, 操作详情, 时间 |
| CF优选IP | 任务列表 | ID, 域名, CDN运营商, 解析数量, IP类型, 任务开关, 更新时间, 更新结果 |
| 定时切换 | 策略列表 | ID, 域名, 时间设置, 切换设置, 运行开关, 上次切换, 下次切换, 添加时间, 备注 |

## 排除的列/页面

- **操作列**：所有页面的操作按钮列不可排序
- **复选框列**：批量选择列不可排序
- **计算字段**：`域名数量`、`绑定域名`、`CNAME记录值` 等运行时计算字段不可排序
- **外部API数据源**：DNS解析记录、权重配置、域名日志、Cloudflare Tunnels — 数据来自第三方API，无法服务端排序

## 后端安全措施

所有排序字段使用白名单校验，防止 SQL 注入
