### PR TITLE
feat: 第三方登录功能, 支持QQ/GitHub/彩虹聚合登录/自定义OIDC/自定义OAuth

### DIFF
--- a/app/command/Reset.php
+++ b/app/command/Reset.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace app\command;
 
-use Exception;
 use think\console\Command;
 use think\console\Input;
 use think\console\input\Argument;
-use think\console\input\Option;
 use think\console\Output;
 use think\facade\Db;
-use think\facade\Config;
 
 class Reset extends Command
 {
@@ -19,29 +16,46 @@ class Reset extends Command
     {
         // 指令配置
         $this->setName('reset')
-            ->addArgument('type', Argument::REQUIRED, '操作类型,pwd:重置密码,totp:关闭TOTP')
-            ->addArgument('username', Argument::REQUIRED, '用户名')
-            ->addArgument('password', Argument::OPTIONAL, '密码')
-            ->setDescription('重置密码');
+            ->addArgument('type', Argument::REQUIRED, '操作类型,pwd:重置密码,totp:关闭TOTP,oauth_disable_password:恢复密码登录')
+            ->addArgument('username', Argument::OPTIONAL, '用户名(pwd/totp必需)')
+            ->addArgument('password', Argument::OPTIONAL, '新密码(仅pwd)')
+            ->setDescription('重置管理命令');
     }
 
     protected function execute(Input $input, Output $output)
     {
         $type = trim($input->getArgument('type'));
+
+        if ($type == 'oauth_disable_password') {
+            config_set('oauth_disable_password', '0');
+            \think\facade\Cache::delete('configs');
+            $output->writeln('密码登录已恢复！现在可以使用用户名和密码登录后台。');
+            return Command::SUCCESS;
+        }
+
         $username = trim($input->getArgument('username'));
+        if (empty($username)) {
+            $output->writeln('用户名不能为空');
+            return Command::FAILURE;
+        }
         $user = Db::name('user')->where('username', $username)->find();
         if (!$user) {
             $output->writeln('用户 ' . $username . ' 不存在');
-            return;
+            return Command::FAILURE;
         }
         if ($type == 'pwd') {
             $password = $input->getArgument('password');
             if (empty($password)) $password = '123456';
             Db::name('user')->where('id', $user['id'])->update(['password' => password_hash($password, PASSWORD_DEFAULT)]);
             $output->writeln('用户 ' . $username . ' 密码重置成功');
+            return Command::SUCCESS;
         } elseif ($type == 'totp') {
             Db::name('user')->where('id', $user['id'])->update(['totp_open' => 0, 'totp_secret' => null]);
             $output->writeln('用户 ' . $username . ' TOTP关闭成功');
+            return Command::SUCCESS;
         }
+
+        $output->writeln('未知操作类型：' . $type);
+        return Command::FAILURE;
     }
 }

--- a/app/common.php
+++ b/app/common.php
@@ -178,15 +178,23 @@ function arrays_are_equal($array1, $array2)
 
 function checkRefererHost()
 {
-    if (!Request::header('referer')) {
+    $source = Request::header('referer') ?: Request::header('origin');
+    if (!$source) {
         return false;
     }
-    $url_arr = parse_url(Request::header('referer'));
-    $http_host = Request::header('host');
-    if (strpos($http_host, ':')) {
-        $http_host = substr($http_host, 0, strpos($http_host, ':'));
+    return isSameSiteSourceHost($source, Request::header('host'));
+}
+
+function isSameSiteSourceHost(string $source, string $host): bool
+{
+    $sourceHost = parse_url($source, PHP_URL_HOST);
+    if (!$sourceHost) {
+        return false;
     }
-    return $url_arr['host'] === $http_host;
+    if (strpos($host, ':')) {
+        $host = substr($host, 0, strpos($host, ':'));
+    }
+    return $sourceHost === $host;
 }
 
 function checkIfActive($string)
@@ -262,6 +270,31 @@ function config_set($key, $value)
     return $res !== false;
 }
 
+function build_guzzle_proxy_url($proxy_server = null, $proxy_port = null, $proxy_type = null, $proxy_user = null, $proxy_pwd = null): ?string
+{
+    $proxy_server ??= config_get('proxy_server');
+    $proxy_port = intval($proxy_port ?? config_get('proxy_port'));
+    if (empty($proxy_server) || empty($proxy_port)) {
+        return null;
+    }
+
+    $proxy_type ??= config_get('proxy_type');
+    $proxy_user = (string)($proxy_user ?? config_get('proxy_user'));
+    $proxy_pwd = (string)($proxy_pwd ?? config_get('proxy_pwd'));
+    $proxy_string = match ($proxy_type) {
+        'https' => 'https://',
+        'sock4' => 'socks4://',
+        'sock5' => 'socks5://',
+        'sock5h' => 'socks5h://',
+        default => 'http://',
+    };
+
+    if ($proxy_user !== '' || $proxy_pwd !== '') {
+        $proxy_string .= rawurlencode($proxy_user) . ':' . rawurlencode($proxy_pwd) . '@';
+    }
+    return $proxy_string . $proxy_server . ':' . $proxy_port;
+}
+
 function getMillisecond()
 {
     list($s1, $s2) = explode(' ', microtime());
@@ -325,19 +358,10 @@ function getMainDomain($host)
 
 function check_proxy($url, $proxy_server, $proxy_port, $type, $proxy_user, $proxy_pwd)
 {
-    match ($type) {
-        'https' => $proxy_string = 'https://',
-        'sock4' => $proxy_string = 'socks4://',
-        'sock5' => $proxy_string = 'socks5://',
-        'sock5h' => $proxy_string = 'socks5h://',
-        default => $proxy_string = 'http://',
-    };
-
-    if (!empty($proxy_user) && !empty($proxy_pwd)) {
-        $proxy_string .= $proxy_user . ':' . $proxy_pwd . '@';
+    $proxy_string = build_guzzle_proxy_url($proxy_server, $proxy_port, $type, $proxy_user, $proxy_pwd);
+    if ($proxy_string === null) {
+        throw new Exception('代理服务器或端口未配置');
     }
-
-    $proxy_string .= $proxy_server . ':' . intval($proxy_port);
     $options = [
         'proxy' => $proxy_string,
         'timeout' => 3,
@@ -482,28 +506,10 @@ function http_request($url, $data = null, $referer = null, $cookie = null, $head
     }
     // 处理代理
     if ($proxy) {
-        $proxy_server = config_get('proxy_server');
-        $proxy_port = intval(config_get('proxy_port'));
-        $proxy_userpwd = config_get('proxy_user').':'.config_get('proxy_pwd');
-        $proxy_type = config_get('proxy_type');
-
-        if (empty($proxy_server) || empty($proxy_port)) {
+        $proxy_string = build_guzzle_proxy_url();
+        if ($proxy_string === null) {
             throw new Exception('代理服务器或端口未配置');
         }
-
-        match ($proxy_type) {
-            'https' => $proxy_string = 'https://',
-            'sock4' => $proxy_string = 'socks4://',
-            'sock5' => $proxy_string = 'socks5://',
-            'sock5h' => $proxy_string = 'socks5h://',
-            default => $proxy_string = 'http://',
-        };
-
-        if ($proxy_userpwd != ':') {
-            $proxy_string .= $proxy_userpwd . '@';
-        }
-
-        $proxy_string .= $proxy_server . ':' . $proxy_port;
         $options['proxy'] = $proxy_string;
     }
 
@@ -610,7 +616,9 @@ function getDomainDate($domain)
 
 function checkTableExists($table)
 {
-    $prefix = env('database.prefix', 'dnsmgr_');
-    $res = Db::query("SHOW TABLES LIKE '" . $prefix . $table . "'");
+    $prefix = (string)config('database.connections.mysql.prefix', env('database.prefix', ''));
+    $tableName = $prefix . $table;
+    $pattern = addcslashes($tableName, "\\_%");
+    $res = Db::query("SHOW TABLES LIKE '" . $pattern . "'");
     return !empty($res);
 }

--- a/app/controller/Auth.php
+++ b/app/controller/Auth.php
@@ -3,6 +3,8 @@
 namespace app\controller;
 
 use app\BaseController;
+use app\service\oauth\OAuthAuthService;
+use app\service\oauth\OAuthProviderService;
 use Exception;
 use think\facade\Db;
 
@@ -19,6 +21,9 @@ class Auth extends BaseController
         }
 
         if ($this->request->isAjax()) {
+            if (config_get('oauth_disable_password', '0') == '1') {
+                return json(['code' => -1, 'msg' => '管理员已禁用密码登录，请使用第三方账号登录']);
+            }
             $username = input('post.username', null, 'trim');
             $password = input('post.password', null, 'trim');
             $code = input('post.code', null, 'trim');
@@ -40,6 +45,8 @@ class Auth extends BaseController
                 if ($user['status'] == 0) return json(['code' => -1, 'msg' => '此用户已被封禁', 'vcode' => 1]);
                 if (isset($user['totp_open']) && $user['totp_open'] == 1 && !empty($user['totp_secret'])) {
                     session('pre_login_user', $user['id']);
+                    session('oauth_totp_pending', null);
+                    session('totp_attempt', null);
                     if (file_exists($login_limit_file)) {
                         unlink($login_limit_file);
                     }
@@ -53,9 +60,6 @@ class Auth extends BaseController
             } else {
                 if ($user) {
                     Db::name('log')->insert(['uid' => $user['id'], 'action' => '登录失败', 'data' => 'IP:' . $this->clientip, 'addtime' => date("Y-m-d H:i:s")]);
-                    if (isset($user['totp_open']) && $user['totp_open'] == 1 && !empty($user['totp_secret'])) {
-                        return json(['code' => -1, 'msg' => '用户名或密码错误', 'vcode' => 1]);
-                    }
                 }
                 if (!file_exists($login_limit_file)) {
                     $login_limit = ['count' => 0, 'time' => 0];
@@ -72,6 +76,11 @@ class Auth extends BaseController
             }
         }
 
+        $providers = (new OAuthProviderService())->getEnabledProviders();
+        \think\facade\View::assign('oauth_providers', $providers);
+        \think\facade\View::assign('oauth_disable_password', config_get('oauth_disable_password', '0'));
+        \think\facade\View::assign('show_totp', input('get.totp/d', 0) == 1 && session('pre_login_user'));
+
         return view();
     }
 
@@ -83,17 +92,48 @@ class Auth extends BaseController
         if (empty($code)) return json(['code' => -1, 'msg' => '请输入动态口令']);
         $user = Db::name('user')->where('id', $uid)->find();
         if (!$user) return json(['code' => -1, 'msg' => '用户不存在']);
+        if ($user['status'] == 0) {
+            session('pre_login_user', null);
+            session('oauth_totp_pending', null);
+            session('totp_attempt', null);
+            return json(['code' => -1, 'msg' => '此用户已被封禁']);
+        }
         if ($user['totp_open'] == 0 || empty($user['totp_secret'])) return json(['code' => -1, 'msg' => '未开启TOTP二次验证']);
+        $totpAttempt = session('totp_attempt') ?: ['count' => 0, 'time' => 0];
+        if (!is_array($totpAttempt)) {
+            $totpAttempt = ['count' => 0, 'time' => 0];
+        }
+        if ($totpAttempt['count'] >= 5 && $totpAttempt['time'] > time() - 600) {
+            session('pre_login_user', null);
+            session('oauth_totp_pending', null);
+            session('totp_attempt', null);
+            return json(['code' => -1, 'msg' => '动态口令错误次数过多，请重新登录']);
+        }
         try {
             $totp = \app\lib\TOTP::create($user['totp_secret']);
             if (!$totp->verify($code)) {
+                $totpAttempt['count']++;
+                $totpAttempt['time'] = time();
+                session('totp_attempt', $totpAttempt);
                 return json(['code' => -1, 'msg' => '动态口令错误']);
             }
         } catch (Exception $e) {
             return json(['code' => -1, 'msg' => $e->getMessage()]);
         }
+        try {
+            $this->completePendingOauthLogin((int)$user['id']);
+        } catch (Exception $e) {
+            session('pre_login_user', null);
+            session('oauth_totp_pending', null);
+            session('totp_attempt', null);
+            trace('OAuth TOTP binding refresh error: user_id=' . $user['id'] . ', message=' . $e->getMessage(), 'error');
+            return json(['code' => -1, 'msg' => $e->getMessage()]);
+        }
+        $this->regenerateSessionIdIfActive();
         $this->loginUser($user);
         session('pre_login_user', null);
+        session('oauth_totp_pending', null);
+        session('totp_attempt', null);
         return json(['code' => 0]);
     }
 
@@ -133,14 +173,36 @@ class Auth extends BaseController
         return redirect('/record/' . $row['id']);
     }
 
+    private function completePendingOauthLogin(int $userId): void
+    {
+        $pending = session('oauth_totp_pending');
+        if (!is_array($pending)) {
+            return;
+        }
+        if ((int)($pending['user_id'] ?? 0) !== $userId) {
+            throw new Exception('OAuth登录状态与当前二次验证用户不匹配，请重新登录');
+        }
+        if (empty($pending['provider']) || empty($pending['userInfo']) || empty($pending['tokenData'])) {
+            throw new Exception('OAuth登录状态已失效，请重新登录');
+        }
+        (new OAuthAuthService())->updateLoginBinding($pending['provider'], $pending['userInfo'], $pending['tokenData']);
+    }
+
+    private function regenerateSessionIdIfActive(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_regenerate_id(true);
+        }
+    }
+
     private function loginUser($user)
     {
         Db::name('log')->insert(['uid' => $user['id'], 'action' => '登录后台', 'data' => 'IP:' . $this->clientip, 'addtime' => date("Y-m-d H:i:s")]);
-        DB::name('user')->where('id', $user['id'])->update(['lasttime' => date("Y-m-d H:i:s")]);
+        Db::name('user')->where('id', $user['id'])->update(['lasttime' => date("Y-m-d H:i:s")]);
         $session = md5($user['id'] . $user['password']);
         $expiretime = time() + 2562000;
         $token = authcode("user\t{$user['id']}\t{$session}\t{$expiretime}", 'ENCODE', config_get('sys_key'));
-        cookie('user_token', $token, ['expire' => $expiretime, 'httponly' => true]);
+        cookie('user_token', $token, ['expire' => $expiretime, 'httponly' => true, 'samesite' => 'Lax', 'secure' => request()->isSsl()]);
     }
 
     private function loginDomain($row)
@@ -149,7 +211,7 @@ class Auth extends BaseController
         $session = md5($row['id'] . $row['name']);
         $expiretime = time() + 2562000;
         $token = authcode("domain\t{$row['id']}\t{$session}\t{$expiretime}", 'ENCODE', config_get('sys_key'));
-        cookie('user_token', $token, ['expire' => $expiretime, 'httponly' => true]);
+        cookie('user_token', $token, ['expire' => $expiretime, 'httponly' => true, 'samesite' => 'Lax', 'secure' => request()->isSsl()]);
     }
 
     public function verifycode()

--- a/app/controller/Index.php
+++ b/app/controller/Index.php
@@ -7,6 +7,7 @@ use Exception;
 use think\facade\Db;
 use think\facade\View;
 use think\facade\Cache;
+use app\service\oauth\OAuthProviderService;
 
 class Index extends BaseController
 {
@@ -83,6 +84,9 @@ class Index extends BaseController
             try {
                 Db::execute($value);
             } catch (Exception $e) {
+                if (str_contains($value, 'oauth_provider') || str_contains($value, 'user_oauth') || str_contains($value, 'oauth_disable_password')) {
+                    throw $e;
+                }
             }
         }
         config_set('version', config('app.dbversion'));
@@ -158,13 +162,13 @@ class Index extends BaseController
             Db::name('user')->where('id', $this->request->user['id'])->update(['password' => password_hash($newpwd, PASSWORD_DEFAULT)]);
             return json(['code' => 0, 'msg' => 'succ']);
         }
-        View::assign('user', $this->request->user);
-        return view();
+        return redirect('/user/center');
     }
 
     public function totp()
     {
         if (!checkPermission(1)) return $this->alert('error', '无权限');
+        if (!checkRefererHost()) return json(['code' => -1, 'msg' => '非法请求']);
         $action = input('param.action');
         if ($action == 'generate') {
             try {
@@ -199,5 +203,17 @@ class Index extends BaseController
     public function test()
     {
 
+    }
+
+    public function userCenter()
+    {
+        if (!checkPermission(1)) return $this->alert('error', '无权限');
+
+        $providers = (new OAuthProviderService())->getEnabledProvidersWithUserBindings((int)$this->request->user['id']);
+
+        \think\facade\View::assign('user', $this->request->user);
+        \think\facade\View::assign('providers', $providers);
+
+        return view();
     }
 }

--- a/app/controller/OauthController.php
+++ b/app/controller/OauthController.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace app\controller;
+
+use app\BaseController;
+use app\lib\oauth\OAuthUserInfo;
+use app\service\oauth\OAuthAuthService;
+use Exception;
+use think\facade\Db;
+
+class OauthController extends BaseController
+{
+    public function login($id)
+    {
+        if ($this->request->islogin) {
+            return redirect('/');
+        }
+
+        try {
+            return redirect((new OAuthAuthService())->buildLoginRedirect((int)$id, $this->getCallbackUrl($id)));
+        } catch (Exception $e) {
+            trace($this->buildOAuthErrorLog('init', (int)$id, null, $e), 'error');
+            return $this->alert('error', '无法跳转到第三方登录，请稍后重试或联系管理员检查登录配置');
+        }
+    }
+
+    public function bind($id)
+    {
+        if (!checkPermission(1)) {
+            return $this->alert('error', '无权限');
+        }
+        if (!checkRefererHost()) {
+            return $this->alert('error', '非法请求');
+        }
+
+        try {
+            return redirect((new OAuthAuthService())->buildBindRedirect((int)$id, (int)$this->request->user['id'], $this->getCallbackUrl($id)));
+        } catch (Exception $e) {
+            trace($this->buildOAuthErrorLog('bind', (int)$id, (int)$this->request->user['id'], $e), 'error');
+            return $this->alert('error', '无法跳转到第三方绑定授权页，请稍后重试或联系管理员检查登录配置');
+        }
+    }
+
+    public function callback($id)
+    {
+        $code = input('get.code', null, 'trim');
+        $state = input('get.state', null, 'trim');
+
+        if (empty($code) || empty($state)) {
+            return $this->alert('error', '授权失败，请重新登录');
+        }
+
+        try {
+            $currentUserId = $this->request->islogin ? (int)$this->request->user['id'] : null;
+            $service = new OAuthAuthService();
+            $result = $service->handleCallback((int)$id, $code, $state, $this->getCallbackUrl($id), $currentUserId);
+            if ($result['type'] === 'alert') {
+                return $this->alert($result['level'], $result['msg'], $result['url'] ?? null);
+            }
+            if (!empty($result['requiresTotp'])) {
+                session('pre_login_user', $result['user']['id']);
+                session('oauth_totp_pending', [
+                    'user_id' => (int)$result['user']['id'],
+                    'provider' => $result['provider'],
+                    'userInfo' => $result['userInfo'],
+                    'tokenData' => $result['tokenData'],
+                ]);
+                session('totp_attempt', null);
+                return redirect('/login?totp=1');
+            }
+            try {
+                $service->updateLoginBinding($result['provider'], $result['userInfo'], $result['tokenData']);
+            } catch (Exception $e) {
+                trace($this->buildOAuthErrorLog('refresh_binding', (int)$id, (int)$result['user']['id'], $e), 'error');
+            }
+            $this->regenerateSessionIdIfActive();
+            $this->loginUser($result['user'], $result['provider'], $result['userInfo']);
+            return redirect('/');
+        } catch (Exception $e) {
+            trace($this->buildOAuthErrorLog('callback', (int)$id, $this->request->islogin ? (int)$this->request->user['id'] : null, $e), 'error');
+            return $this->alert('error', $this->buildUserFacingOauthMessage($e));
+        }
+    }
+
+    public function unbind()
+    {
+        if (!checkPermission(1)) {
+            return json(['code' => -1, 'msg' => '无权限']);
+        }
+        if (!checkRefererHost()) {
+            return json(['code' => -1, 'msg' => '非法请求']);
+        }
+
+        $providerId = input('post.provider_id/d');
+        if (empty($providerId)) {
+            return json(['code' => -1, 'msg' => '参数错误']);
+        }
+
+        try {
+            (new OAuthAuthService())->unbind((int)$this->request->user['id'], (int)$providerId);
+            return json(['code' => 0, 'msg' => '解绑成功']);
+        } catch (Exception $e) {
+            trace($this->buildOAuthErrorLog('unbind', (int)$providerId, (int)$this->request->user['id'], $e), 'error');
+            return json(['code' => -1, 'msg' => $this->buildUserFacingOauthMessage($e)]);
+        }
+    }
+
+    private function regenerateSessionIdIfActive(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_regenerate_id(true);
+        }
+    }
+
+    private function loginUser(array $user, array $provider, OAuthUserInfo $userInfo): void
+    {
+        Db::name('log')->insert([
+            'uid' => $user['id'],
+            'action' => 'OAuth登录后台',
+            'data' => 'Provider:' . $provider['name'] . ', IP:' . $this->clientip,
+            'addtime' => date('Y-m-d H:i:s'),
+        ]);
+        Db::name('user')->where('id', $user['id'])->update(['lasttime' => date('Y-m-d H:i:s')]);
+
+        $session = md5($user['id'] . $user['password']);
+        $expiretime = time() + 2562000;
+        $token = authcode("user\t{$user['id']}\t{$session}\t{$expiretime}", 'ENCODE', config_get('sys_key'));
+        cookie('user_token', $token, ['expire' => $expiretime, 'httponly' => true, 'samesite' => 'Lax', 'secure' => request()->isSsl()]);
+    }
+
+    private function buildUserFacingOauthMessage(Exception $e): string
+    {
+        $message = trim($e->getMessage());
+        if ($message === '') {
+            return '第三方登录失败：服务返回了空错误信息，请重新发起登录';
+        }
+        $message = $this->redactOAuthMessage($message);
+        return '第三方登录失败：' . $message;
+    }
+
+    private function buildOAuthErrorLog(string $flow, int $providerId, ?int $userId, Exception $e): string
+    {
+        return 'OAuth ' . $flow . ' error: provider_id=' . $providerId . ', user_id=' . ($userId ?? 0) . ', message=' . $this->redactOAuthMessage($e->getMessage());
+    }
+
+    private function redactOAuthMessage(string $message): string
+    {
+        $keys = 'access_token|refresh_token|client_secret|appkey|appid|id_token|code';
+        $message = preg_replace('/(' . $keys . ')=([^&\s]+)/i', '$1=[redacted]', $message);
+        $message = preg_replace('/("(?:' . $keys . ')"\s*:\s*")[^"]*(")/i', '$1[redacted]$2', $message);
+        return preg_replace('/Bearer\s+[A-Za-z0-9._~+\/-]+=*/i', 'Bearer [redacted]', $message);
+    }
+
+    private function getCallbackUrl($id): string
+    {
+        $baseUrl = config('app.app_host') ?: request()->root(true);
+        return rtrim($baseUrl, '/') . '/oauth/callback/' . $id;
+    }
+}

--- a/app/controller/System.php
+++ b/app/controller/System.php
@@ -11,16 +11,94 @@ use app\service\OptimizeService;
 use app\service\CertTaskService;
 use app\service\ExpireNoticeService;
 use app\service\ScheduleService;
+use app\service\oauth\OAuthProviderService;
 
 class System extends BaseController
 {
     public function set()
     {
         if (!checkPermission(2)) return $this->alert('error', '无权限');
+        if (!checkRefererHost()) return json(['code' => -1, 'msg' => '非法请求']);
         $params = input('post.');
+        unset($params['submit']);
+        $allowedConfigKeys = [
+            'vcode',
+            'oauth_disable_password',
+            'cert_renewdays',
+            'deploy_hour_start',
+            'deploy_hour_end',
+            'cert_notice_mail',
+            'cert_notice_wxtpl',
+            'cert_notice_tgbot',
+            'cert_notice_webhook',
+            'cert_notice_custom_webhook',
+            'proxy_server',
+            'proxy_port',
+            'proxy_user',
+            'proxy_pwd',
+            'proxy_type',
+            'cron_type',
+            'cron_key',
+            'mail_type',
+            'mail_smtp',
+            'mail_port',
+            'mail_name',
+            'mail_name2',
+            'mail_pwd',
+            'mail_apiuser',
+            'mail_apikey',
+            'mail_recv',
+            'wechat_apptoken',
+            'wechat_appuid',
+            'tgbot_token',
+            'tgbot_chatid',
+            'tgbot_proxy',
+            'tgbot_url',
+            'webhook_url',
+            'webhook_user',
+            'custom_webhook_url',
+            'custom_webhook_method',
+            'custom_webhook_content_type',
+            'custom_webhook_headers',
+            'custom_webhook_body',
+            'custom_webhook_content_format',
+            'optimize_ip_api',
+            'optimize_ip_key',
+            'optimize_ip_proxy',
+            'optimize_ip_min',
+            'expire_noticedays',
+            'expire_notice_mail',
+            'expire_notice_wxtpl',
+            'expire_notice_tgbot',
+            'expire_notice_webhook',
+            'expire_notice_custom_webhook',
+            'notice_mail',
+            'notice_wxtpl',
+            'notice_tgbot',
+            'notice_webhook',
+            'notice_custom_webhook',
+        ];
+        foreach (array_keys($params) as $key) {
+            if (!in_array($key, $allowedConfigKeys, true)) {
+                return json(['code' => -1, 'msg' => '非法配置项']);
+            }
+        }
         if (isset($params['mail_type']) && isset($params['mail_name2']) && $params['mail_type'] > 0) {
             $params['mail_name'] = $params['mail_name2'];
             unset($params['mail_name2']);
+        }
+        if (isset($params['mail_name2'])) {
+            unset($params['mail_name2']);
+        }
+        // 禁用密码登录保护：至少有一个启用的 OAuth 提供商，且至少一个可用管理员已绑定
+        if (isset($params['oauth_disable_password']) && $params['oauth_disable_password'] == '1') {
+            $count = Db::name('oauth_provider')->where('enabled', 1)->count();
+            if ($count == 0) {
+                return json(['code' => -1, 'msg' => '至少需要启用一个OAuth提供商才能禁用密码登录']);
+            }
+            if (!(new OAuthProviderService())->hasAdminOauthBinding()) {
+                return json(['code' => -1, 'msg' => '至少需要一个超级管理员账号绑定已启用的OAuth提供商，才能禁用密码登录']);
+            }
         }
         foreach ($params as $key => $value) {
             if (empty($key)) {
@@ -35,6 +113,7 @@ class System extends BaseController
     public function loginset()
     {
         if (!checkPermission(2)) return $this->alert('error', '无权限');
+        View::assign('siteurl', request()->root(true));
         return View::fetch();
     }
 
@@ -160,5 +239,57 @@ class System extends BaseController
             (new ExpireNoticeService())->task();
         }
         echo 'success!';
+    }
+
+    public function oauth_data()
+    {
+        if (!checkPermission(2)) return json(['total' => 0, 'rows' => []]);
+        $offset = input('post.offset/d', 0);
+        $limit = input('post.limit/d', 10);
+        $sort = input('post.sort', 'sort');
+        $order = input('post.order', 'asc');
+
+        return json((new OAuthProviderService())->list($offset, $limit, $sort, $order));
+    }
+
+    public function oauth_op()
+    {
+        if (!checkPermission(2)) return json(['code' => -1, 'msg' => '无权限']);
+        if (!checkRefererHost()) return json(['code' => -1, 'msg' => '非法请求']);
+        $act = input('param.act');
+        $service = new OAuthProviderService();
+
+        try {
+            if ($act == 'get') {
+                return json(['code' => 0, 'data' => $service->get(input('post.id/d'))]);
+            } elseif ($act == 'add' || $act == 'edit') {
+                $isEdit = ($act == 'edit');
+                $id = $isEdit ? input('post.id/d') : 0;
+                $data = [
+                    'name' => input('post.name', '', 'trim'),
+                    'type' => input('post.type', '', 'trim'),
+                    'logo' => input('post.logo', '', 'trim'),
+                    'client_id' => input('post.client_id', '', 'trim'),
+                    'client_secret' => input('post.client_secret', '', 'trim'),
+                    'scopes' => input('post.scopes', '', 'trim'),
+                    'oauth_authorize_url' => input('post.oauth_authorize_url', '', 'trim'),
+                    'oauth_token_url' => input('post.oauth_token_url', '', 'trim'),
+                    'oauth_userinfo_url' => input('post.oauth_userinfo_url', '', 'trim'),
+                    'oidc_issuer' => input('post.oidc_issuer', '', 'trim'),
+                    'userinfo_fields' => input('post.userinfo_fields', '', 'trim'),
+                    'ext_config' => input('post.ext_config', '', 'trim'),
+                    'sort' => input('post.sort/d', 0),
+                    'enabled' => input('post.enabled/d', 1),
+                ];
+                $service->save($data, $isEdit, $id);
+                return json(['code' => 0, 'msg' => $isEdit ? '修改成功' : '添加成功']);
+            } elseif ($act == 'del') {
+                $service->delete(input('post.id/d'));
+                return json(['code' => 0, 'msg' => '删除成功']);
+            }
+        } catch (Exception $e) {
+            return json(['code' => -1, 'msg' => $e->getMessage()]);
+        }
+        return json(['code' => -3]);
     }
 }

--- a/app/controller/User.php
+++ b/app/controller/User.php
@@ -3,6 +3,7 @@
 namespace app\controller;
 
 use app\BaseController;
+use app\service\oauth\OAuthProviderService;
 use think\facade\Db;
 use think\facade\View;
 use think\facade\Request;
@@ -115,25 +116,32 @@ class User extends BaseController
             if ($level == 1 && ($id == 1000 || $id == $this->request->user['id'])) {
                 $level = 2;
             }
-            Db::name('user')->where('id', $id)->update([
-                'username' => $username,
-                'is_api' => $is_api,
-                'apikey' => $apikey,
-                'level' => $level,
-            ]);
-            Db::name('permission')->where(['uid' => $id])->delete();
-            if ($level == 1) {
-                $permission = input('post.permission/a');
-                if (!empty($permission)) {
-                    $data = [];
-                    foreach ($permission as $domain) {
-                        $data[] = ['uid' => $id, 'domain' => $domain];
+            try {
+                Db::transaction(function () use ($id, $username, $is_api, $apikey, $level, $repwd) {
+                    $this->assertOauthPasswordFallbackSafe($id, $level, 1);
+                    Db::name('user')->where('id', $id)->update([
+                        'username' => $username,
+                        'is_api' => $is_api,
+                        'apikey' => $apikey,
+                        'level' => $level,
+                    ]);
+                    Db::name('permission')->where(['uid' => $id])->delete();
+                    if ($level == 1) {
+                        $permission = input('post.permission/a');
+                        if (!empty($permission)) {
+                            $data = [];
+                            foreach ($permission as $domain) {
+                                $data[] = ['uid' => $id, 'domain' => $domain];
+                            }
+                            Db::name('permission')->insertAll($data);
+                        }
                     }
-                    Db::name('permission')->insertAll($data);
-                }
-            }
-            if (!empty($repwd)) {
-                Db::name('user')->where('id', $id)->update(['password' => password_hash($repwd, PASSWORD_DEFAULT)]);
+                    if (!empty($repwd)) {
+                        Db::name('user')->where('id', $id)->update(['password' => password_hash($repwd, PASSWORD_DEFAULT)]);
+                    }
+                });
+            } catch (\Exception $e) {
+                return json(['code' => -1, 'msg' => $e->getMessage()]);
             }
             return json(['code' => 0, 'msg' => '修改用户成功！']);
         } elseif ($act == 'set') {
@@ -145,7 +153,14 @@ class User extends BaseController
             if ($id == $this->request->user['id']) {
                 return json(['code' => -1, 'msg' => '当前登录用户无法修改状态']);
             }
-            Db::name('user')->where('id', $id)->update(['status' => $status]);
+            try {
+                Db::transaction(function () use ($id, $status) {
+                    $this->assertOauthPasswordFallbackSafe($id, 2, $status);
+                    Db::name('user')->where('id', $id)->update(['status' => $status]);
+                });
+            } catch (\Exception $e) {
+                return json(['code' => -1, 'msg' => $e->getMessage()]);
+            }
             return json(['code' => 0]);
         } elseif ($act == 'del') {
             $id = input('post.id/d');
@@ -155,10 +170,35 @@ class User extends BaseController
             if ($id == $this->request->user['id']) {
                 return json(['code' => -1, 'msg' => '当前登录用户无法删除']);
             }
-            Db::name('user')->where('id', $id)->delete();
+            try {
+                Db::transaction(function () use ($id) {
+                    $this->assertOauthPasswordFallbackSafe($id, 1, 0);
+                    Db::name('user_oauth')->where('user_id', $id)->delete();
+                    Db::name('user')->where('id', $id)->delete();
+                });
+            } catch (\Exception $e) {
+                return json(['code' => -1, 'msg' => $e->getMessage()]);
+            }
             return json(['code' => 0]);
         }
         return json(['code' => -3]);
+    }
+
+    private function assertOauthPasswordFallbackSafe(int $id, int $targetLevel, int $targetStatus): void
+    {
+        if (config_get('oauth_disable_password', '0') != '1') {
+            return;
+        }
+        $user = Db::name('user')->where('id', $id)->lock(true)->find();
+        if (!$user || (int)$user['level'] !== 2 || (int)$user['status'] !== 1) {
+            return;
+        }
+        if ($targetLevel === 2 && $targetStatus === 1) {
+            return;
+        }
+        if (!(new OAuthProviderService())->hasAdminOauthBinding(0, true, $id)) {
+            throw new \Exception('密码登录已禁用，不能移除最后一个可用的超级管理员OAuth登录入口');
+        }
     }
 
     public function log()

--- a/app/lib/OAuth.php
+++ b/app/lib/OAuth.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace app\lib;
+
+use app\lib\oauth\OAuthHttpClient;
+use app\lib\oauth\OAuthProviderFactory;
+use app\lib\oauth\OAuthProviderInterface;
+use app\lib\oauth\OAuthTokenData;
+use app\lib\oauth\OAuthUserInfo;
+
+abstract class OAuth implements OAuthProviderInterface
+{
+    protected array $config;
+    protected string $redirectUri;
+    protected OAuthHttpClient $httpClient;
+    protected string $state = '';
+
+    public function __construct(array $config, ?OAuthHttpClient $httpClient = null)
+    {
+        $this->config = $config;
+        $this->httpClient = $httpClient ?: new OAuthHttpClient();
+    }
+
+    public function setRedirectUri(string $uri): void
+    {
+        $this->redirectUri = $uri;
+    }
+
+    public function setState(string $state): void
+    {
+        $this->state = $state;
+    }
+
+    protected function createPkceVerifier(string $state): string
+    {
+        $verifier = rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+        session('oauth_pkce_' . $state, $verifier);
+        return $verifier;
+    }
+
+    protected function consumePkceVerifier(string $state): string
+    {
+        if ($state === '') {
+            throw new \Exception('OAuth授权状态缺失，请重新发起第三方登录');
+        }
+        $key = 'oauth_pkce_' . $state;
+        $verifier = (string)session($key);
+        session($key, null);
+        if ($verifier === '') {
+            throw new \Exception('OAuth PKCE验证信息已失效，请重新发起第三方登录');
+        }
+        return $verifier;
+    }
+
+    protected function createPkceChallenge(string $verifier): string
+    {
+        return rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+    }
+
+    public static function create(array $providerConfig): OAuthProviderInterface
+    {
+        return (new OAuthProviderFactory())->create($providerConfig);
+    }
+
+    abstract public function getAuthorizeUrl(string $state): string;
+
+    abstract public function getAccessToken(string $code, string $state = ''): OAuthTokenData;
+
+    abstract public function getUserInfo(string $accessToken): OAuthUserInfo;
+
+    protected function httpGet(string $url, array $headers = []): array
+    {
+        return $this->httpClient->get($url, $headers);
+    }
+
+    protected function httpPost(string $url, array|string $data, array $headers = []): array
+    {
+        return $this->httpClient->post($url, $data, $headers);
+    }
+
+    protected function jsonGet(string $url, array $headers = []): array
+    {
+        return $this->httpClient->getJson($url, $headers);
+    }
+
+    protected function jsonPost(string $url, array|string $data, array $headers = []): array
+    {
+        return $this->httpClient->postJson($url, $data, $headers);
+    }
+}

--- a/app/lib/oauth/Cccyun.php
+++ b/app/lib/oauth/Cccyun.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace app\lib\oauth;
+
+use app\lib\OAuth;
+use Exception;
+
+class Cccyun extends OAuth
+{
+    private const DEFAULT_BASE_URL = 'https://u.cccyun.cc/';
+    public const SUPPORTED_TYPES = ['qq', 'wx', 'alipay', 'sina', 'baidu', 'huawei', 'xiaomi', 'douyin', 'bilibili', 'dingtalk'];
+
+    private ?array $callbackData = null;
+
+    public function getAuthorizeUrl(string $state): string
+    {
+        $data = $this->jsonGet($this->buildApiUrl([
+            'act' => 'login',
+            'appid' => (string)$this->config['client_id'],
+            'appkey' => (string)$this->config['client_secret'],
+            'type' => $this->getCccyunType(),
+            'redirect_uri' => $this->appendQuery($this->redirectUri, ['state' => $state]),
+        ]));
+
+        if ((int)($data['code'] ?? -1) !== 0) {
+            throw new Exception('彩虹聚合登录授权地址获取失败：' . (string)($data['msg'] ?? '未知错误'));
+        }
+        if (empty($data['url'])) {
+            throw new Exception('彩虹聚合登录授权地址获取失败：服务未返回跳转地址');
+        }
+
+        return (string)$data['url'];
+    }
+
+    public function getAccessToken(string $code, string $state = ''): OAuthTokenData
+    {
+        $data = $this->jsonGet($this->buildApiUrl([
+            'act' => 'callback',
+            'appid' => (string)$this->config['client_id'],
+            'appkey' => (string)$this->config['client_secret'],
+            'type' => $this->getCccyunType(),
+            'code' => $code,
+        ]));
+
+        $resultCode = (int)($data['code'] ?? -1);
+        if ($resultCode === 2) {
+            throw new Exception('彩虹聚合登录尚未完成，请重新发起第三方登录');
+        }
+        if ($resultCode !== 0) {
+            throw new Exception('彩虹聚合登录授权失败：' . (string)($data['msg'] ?? '未知错误'));
+        }
+        if (empty($data['access_token'])) {
+            throw new Exception('彩虹聚合登录授权失败：未获取到访问令牌');
+        }
+        if (empty($data['social_uid'])) {
+            throw new Exception('彩虹聚合登录获取用户标识失败');
+        }
+
+        $this->callbackData = $data;
+        return OAuthTokenData::fromArray($data);
+    }
+
+    public function getUserInfo(string $accessToken): OAuthUserInfo
+    {
+        if (!$this->callbackData) {
+            throw new Exception('彩虹聚合登录用户信息已失效，请重新发起登录');
+        }
+
+        return new OAuthUserInfo(
+            (string)$this->callbackData['social_uid'],
+            (string)($this->callbackData['nickname'] ?? ''),
+            '',
+            (string)($this->callbackData['faceimg'] ?? ''),
+            null,
+            null,
+            $this->callbackData
+        );
+    }
+
+    private function getCccyunType(): string
+    {
+        $type = (string)($this->getExtConfig()['cccyun_type'] ?? '');
+        if (!in_array($type, self::SUPPORTED_TYPES, true)) {
+            throw new Exception('彩虹聚合登录配置异常：请选择有效的登录方式');
+        }
+        return $type;
+    }
+
+    private function getExtConfig(): array
+    {
+        if (!empty($this->config['ext_config'])) {
+            $ext = json_decode((string)$this->config['ext_config'], true);
+            if (is_array($ext)) {
+                return $ext;
+            }
+        }
+        return [];
+    }
+
+    private function buildApiUrl(array $params): string
+    {
+        return $this->getApiUrl() . '?' . http_build_query($params);
+    }
+
+    private function getApiUrl(): string
+    {
+        $baseUrl = trim((string)($this->getExtConfig()['cccyun_url'] ?? '')) ?: self::DEFAULT_BASE_URL;
+        return rtrim($baseUrl, '/') . '/connect.php';
+    }
+
+    private function appendQuery(string $url, array $params): string
+    {
+        return $url . (str_contains($url, '?') ? '&' : '?') . http_build_query($params);
+    }
+}

--- a/app/lib/oauth/GitHub.php
+++ b/app/lib/oauth/GitHub.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace app\lib\oauth;
+
+use app\lib\OAuth;
+use Exception;
+
+class GitHub extends OAuth
+{
+    public function getAuthorizeUrl(string $state): string
+    {
+        $verifier = $this->createPkceVerifier($state);
+        $params = http_build_query([
+            'client_id' => $this->config['client_id'],
+            'redirect_uri' => $this->redirectUri,
+            'state' => $state,
+            'scope' => $this->config['scopes'] ?: 'read:user user:email',
+            'code_challenge' => $this->createPkceChallenge($verifier),
+            'code_challenge_method' => 'S256',
+        ]);
+        return 'https://github.com/login/oauth/authorize?' . $params;
+    }
+
+    public function getAccessToken(string $code, string $state = ''): OAuthTokenData
+    {
+        $data = $this->jsonPost('https://github.com/login/oauth/access_token', [
+            'client_id' => $this->config['client_id'],
+            'client_secret' => $this->config['client_secret'],
+            'code' => $code,
+            'redirect_uri' => $this->redirectUri,
+            'code_verifier' => $this->consumePkceVerifier($state),
+        ], [
+            'Accept' => 'application/json',
+        ]);
+
+        if (empty($data['access_token'])) {
+            throw new Exception('GitHub获取access_token失败');
+        }
+        return OAuthTokenData::fromArray($data);
+    }
+
+    public function getUserInfo(string $accessToken): OAuthUserInfo
+    {
+        $headers = [
+            'Authorization' => 'Bearer ' . $accessToken,
+            'Accept' => 'application/json',
+        ];
+
+        $userData = $this->jsonGet('https://api.github.com/user', $headers);
+        if (empty($userData['id'])) {
+            throw new Exception('GitHub获取用户信息失败');
+        }
+
+        $email = $userData['email'] ?? '';
+        if (empty($email)) {
+            $emails = $this->jsonGet('https://api.github.com/user/emails', $headers);
+            foreach ($emails as $item) {
+                if (!empty($item['primary']) && !empty($item['verified'])) {
+                    $email = $item['email'];
+                    break;
+                }
+            }
+            if (empty($email)) {
+                foreach ($emails as $item) {
+                    if (!empty($item['verified'])) {
+                        $email = $item['email'];
+                        break;
+                    }
+                }
+            }
+        }
+
+        return new OAuthUserInfo(
+            (string)$userData['id'],
+            $userData['login'] ?? '',
+            $email,
+            $userData['avatar_url'] ?? '',
+            null,
+            null,
+            $userData
+        );
+    }
+}

--- a/app/lib/oauth/OAuth2.php
+++ b/app/lib/oauth/OAuth2.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace app\lib\oauth;
+
+use app\lib\OAuth;
+use Exception;
+
+class OAuth2 extends OAuth
+{
+    private function getFieldMap(): array
+    {
+        $defaults = ['openid' => 'id,sub,openid,user_id', 'nickname' => 'name,nickname,preferred_username,login,username', 'email' => 'email', 'avatar' => 'avatar,avatar_url,picture'];
+        if (!empty($this->config['userinfo_fields'])) {
+            $custom = json_decode($this->config['userinfo_fields'], true);
+            if (is_array($custom)) {
+                return array_merge($defaults, $custom);
+            }
+        }
+        return $defaults;
+    }
+
+    public function getAuthorizeUrl(string $state): string
+    {
+        if (!(new OAuthUrlValidator())->isSafeHttpsUrl($this->config['oauth_authorize_url'])) {
+            throw new Exception('自定义OAuth2授权端点URL不安全');
+        }
+        $verifier = $this->createPkceVerifier($state);
+        $params = http_build_query([
+            'response_type' => 'code',
+            'client_id' => $this->config['client_id'],
+            'redirect_uri' => $this->redirectUri,
+            'state' => $state,
+            'scope' => $this->config['scopes'] ?? '',
+            'code_challenge' => $this->createPkceChallenge($verifier),
+            'code_challenge_method' => 'S256',
+        ]);
+        return $this->appendQuery($this->config['oauth_authorize_url'], $params);
+    }
+
+    public function getAccessToken(string $code, string $state = ''): OAuthTokenData
+    {
+        if (!(new OAuthUrlValidator())->isSafeHttpsUrl($this->config['oauth_token_url'])) {
+            throw new Exception('自定义OAuth2 Token端点URL不安全');
+        }
+        $data = $this->jsonPost($this->config['oauth_token_url'], [
+            'grant_type' => 'authorization_code',
+            'client_id' => $this->config['client_id'],
+            'client_secret' => $this->config['client_secret'],
+            'code' => $code,
+            'redirect_uri' => $this->redirectUri,
+            'code_verifier' => $this->consumePkceVerifier($state),
+        ], [
+            'Accept' => 'application/json',
+        ]);
+
+        if (empty($data['access_token'])) {
+            throw new Exception('获取access_token失败');
+        }
+        return OAuthTokenData::fromArray($data);
+    }
+
+    public function getUserInfo(string $accessToken): OAuthUserInfo
+    {
+        $headers = [
+            'Authorization' => 'Bearer ' . $accessToken,
+            'Accept' => 'application/json',
+        ];
+
+        if (!(new OAuthUrlValidator())->isSafeHttpsUrl($this->config['oauth_userinfo_url'])) {
+            throw new Exception('自定义OAuth2用户信息端点URL不安全');
+        }
+        $data = $this->jsonGet($this->config['oauth_userinfo_url'], $headers);
+        $map = $this->getFieldMap();
+        $openid = (string)($this->getByPath($data, $map['openid']) ?? '');
+        if ($openid === '') {
+            throw new Exception('自定义OAuth2获取用户标识失败：请在字段映射中把 openid 映射到用户信息接口返回的唯一ID字段，例如 {"openid":"sub"} 或 {"openid":"id"}');
+        }
+
+        return new OAuthUserInfo(
+            $openid,
+            (string)($this->getByPath($data, $map['nickname']) ?? ''),
+            (string)($this->getByPath($data, $map['email']) ?? ''),
+            (string)($this->getByPath($data, $map['avatar']) ?? ''),
+            null,
+            null,
+            $data
+        );
+    }
+
+    private function appendQuery(string $url, string $query): string
+    {
+        return $url . (str_contains($url, '?') ? '&' : '?') . $query;
+    }
+
+    private function getByPath(array $data, string $path): mixed
+    {
+        foreach (explode(',', $path) as $candidatePath) {
+            $candidatePath = trim($candidatePath);
+            if ($candidatePath === '') {
+                continue;
+            }
+            $value = $data;
+            foreach (explode('.', $candidatePath) as $segment) {
+                if (!is_array($value) || !array_key_exists($segment, $value)) {
+                    continue 2;
+                }
+                $value = $value[$segment];
+            }
+            if ($value !== null && $value !== '') {
+                return $value;
+            }
+        }
+        return null;
+    }
+}

--- a/app/lib/oauth/OAuthHttpClient.php
+++ b/app/lib/oauth/OAuthHttpClient.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace app\lib\oauth;
+
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+
+class OAuthHttpClient
+{
+    public function get(string $url, array $headers = []): array
+    {
+        return $this->request($url, null, $headers, 'GET');
+    }
+
+    public function post(string $url, array|string $data, array $headers = []): array
+    {
+        return $this->request($url, $data, $headers, 'POST');
+    }
+
+    public function getJson(string $url, array $headers = []): array
+    {
+        return $this->decodeJson($this->get($url, $headers)['body'], $url);
+    }
+
+    public function postJson(string $url, array|string $data, array $headers = []): array
+    {
+        return $this->decodeJson($this->post($url, $data, $headers)['body'], $url);
+    }
+
+    private function request(string $url, array|string|null $data, array $headers, string $method): array
+    {
+        $urlValidator = new OAuthUrlValidator();
+        if (!$urlValidator->isSafeHttpsUrl($url)) {
+            throw new Exception('OAuth端点URL必须使用安全的HTTPS公网地址');
+        }
+        $options = [
+            'timeout' => 10,
+            'connect_timeout' => 10,
+            'allow_redirects' => false,
+            'verify' => true,
+            'http_errors' => false,
+            'headers' => array_merge([
+                'User-Agent' => 'DNSMgr OAuth Client',
+            ], $headers),
+        ];
+        $proxyUrl = build_guzzle_proxy_url();
+        if ($proxyUrl !== null) {
+            $options['proxy'] = $proxyUrl;
+        }
+
+        if ($data !== null) {
+            if (is_array($data)) {
+                $options['form_params'] = $data;
+                if (!isset($options['headers']['Content-Type'])) {
+                    $options['headers']['Content-Type'] = 'application/x-www-form-urlencoded';
+                }
+            } else {
+                $options['body'] = $data;
+            }
+        }
+
+        try {
+            $response = (new Client())->request($method, $url, $options);
+            $statusCode = $response->getStatusCode();
+            $body = $response->getBody()->getContents();
+            if ($statusCode >= 400) {
+                trace('OAuth HTTP响应异常: ' . $statusCode . ' ' . $this->safeHost($url), 'error');
+                throw new Exception($this->statusMessage($statusCode, $url));
+            }
+            return [
+                'code' => $statusCode,
+                'redirect_url' => $statusCode >= 300 && $statusCode < 400 ? $response->getHeaderLine('Location') : '',
+                'headers' => $response->getHeaders(),
+                'body' => $body,
+            ];
+        } catch (ConnectException $e) {
+            trace('OAuth连接失败: ' . $this->safeHost($url) . ' ' . $this->redactSensitiveMessage($e->getMessage()), 'error');
+            throw new Exception('无法连接到OAuth提供商（' . $this->safeHost($url) . '），请检查网络、代理或提供商地址');
+        } catch (RequestException $e) {
+            trace('OAuth请求异常: ' . $this->safeHost($url) . ' ' . $this->redactSensitiveMessage($e->getMessage()), 'error');
+            throw new Exception($this->requestMessage($e, $url));
+        } catch (GuzzleException $e) {
+            trace('OAuth HTTP请求失败: ' . $this->safeHost($url) . ' ' . $this->redactSensitiveMessage($e->getMessage()), 'error');
+            throw new Exception('请求OAuth提供商失败（' . $this->safeHost($url) . '），请稍后重试或检查配置');
+        }
+    }
+
+    public function decodeJson(string $body, string $url = ''): array
+    {
+        $data = json_decode($body, true);
+        if (!is_array($data)) {
+            throw new Exception('OAuth提供商返回的数据格式不正确（' . $this->safeHost($url) . '），请检查端点地址和响应格式');
+        }
+        return $data;
+    }
+
+    private function safeHost(string $url): string
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        return $host ?: '未知主机';
+    }
+
+    private function redactSensitiveMessage(string $message): string
+    {
+        foreach (['access_token', 'refresh_token', 'client_secret', 'appkey', 'appid', 'code', 'id_token'] as $key) {
+            $message = preg_replace('/(' . preg_quote($key, '/') . '=)[^&\s]*/i', '$1[redacted]', $message);
+            $message = preg_replace('/("' . preg_quote($key, '/') . '"\s*:\s*")[^"]*(")/i', '$1[redacted]$2', $message);
+        }
+        return $message;
+    }
+
+    private function statusMessage(int $statusCode, string $url): string
+    {
+        $host = $this->safeHost($url);
+        return match ($statusCode) {
+            400 => 'OAuth提供商拒绝请求（400，' . $host . '），请检查回调地址、授权码或请求参数',
+            401, 403 => 'OAuth提供商认证失败（' . $statusCode . '，' . $host . '），请检查 Client ID 和 Client Secret',
+            404 => 'OAuth端点不存在（404，' . $host . '），请检查授权、Token 或用户信息端点地址',
+            429 => 'OAuth提供商请求过于频繁（429，' . $host . '），请稍后重试',
+            default => 'OAuth提供商返回异常状态码（' . $statusCode . '，' . $host . '），请稍后重试或检查配置',
+        };
+    }
+
+    private function requestMessage(RequestException $e, string $url): string
+    {
+        if ($e->getResponse()) {
+            return $this->statusMessage($e->getResponse()->getStatusCode(), $url);
+        }
+        $message = strtolower($e->getMessage());
+        if (str_contains($message, 'timed out') || str_contains($message, 'timeout')) {
+            return '请求OAuth提供商超时（' . $this->safeHost($url) . '），请检查网络或代理设置';
+        }
+        if (str_contains($message, 'ssl') || str_contains($message, 'certificate')) {
+            return 'OAuth提供商TLS证书验证失败（' . $this->safeHost($url) . '），请检查HTTPS证书或服务器时间';
+        }
+        return '请求OAuth提供商失败（' . $this->safeHost($url) . '），请检查网络或配置';
+    }
+}

--- a/app/lib/oauth/OAuthProviderConfigValidator.php
+++ b/app/lib/oauth/OAuthProviderConfigValidator.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace app\lib\oauth;
+
+use Exception;
+
+class OAuthProviderConfigValidator
+{
+    private array $types = ['qq', 'github', 'oauth2', 'oidc', 'cccyun'];
+
+    public function __construct(private ?OAuthUrlValidator $urlValidator = null)
+    {
+        $this->urlValidator = $urlValidator ?: new OAuthUrlValidator();
+    }
+
+    public function validate(array $data, bool $isEdit = false): array
+    {
+        if (empty($data['name']) || empty($data['type']) || empty($data['client_id']) || (!$isEdit && empty($data['client_secret']))) {
+            throw new Exception('请填写显示名称、提供商类型、Client ID 和 Client Secret（编辑时可留空 Secret）');
+        }
+        if (!in_array($data['type'], $this->types, true)) {
+            throw new Exception('不支持的提供商类型');
+        }
+        if ($data['type'] === 'oauth2') {
+            foreach (['oauth_authorize_url', 'oauth_token_url', 'oauth_userinfo_url'] as $field) {
+                if (empty($data[$field])) {
+                    throw new Exception('自定义 OAuth2 配置不完整：请填写授权端点 URL、Token 端点 URL、用户信息端点 URL');
+                }
+                $this->validateLength($data[$field], 1024, '端点 URL');
+                if (!$this->urlValidator->isSafeHttpsUrl($data[$field])) {
+                    throw new Exception('端点 URL 不可用：请确认使用 https:// 开头、域名可公网解析，且不能指向内网或 localhost');
+                }
+            }
+        }
+        if ($data['type'] === 'oidc') {
+            if (empty($data['oidc_issuer'])) {
+                throw new Exception('请填写 OIDC Issuer URL，例如 https://accounts.example.com，不要填写 /.well-known 完整路径');
+            }
+            $this->validateLength($data['oidc_issuer'], 1024, 'OIDC Issuer URL');
+            if (!$this->urlValidator->isSafeHttpsUrl($data['oidc_issuer'])) {
+                throw new Exception('OIDC Issuer URL 不可用：请确认使用 https:// 开头、域名可公网解析，且不能指向内网或 localhost');
+            }
+        }
+        $this->validateLength($data['scopes'] ?? '', 1024, 'Scope');
+        $this->validateLength($data['userinfo_fields'] ?? '', 65535, '字段映射');
+        $this->validateJson($data['userinfo_fields'] ?? '', '字段映射', true);
+        $this->validateLength($data['ext_config'] ?? '', 65535, '扩展配置');
+        $this->validateJson($data['ext_config'] ?? '', '扩展配置');
+        if ($data['type'] === 'cccyun') {
+            $this->validateCccyunConfig($data['ext_config'] ?? '');
+        }
+        return $data;
+    }
+
+    private function validateCccyunConfig(string $extConfig): void
+    {
+        $ext = json_decode($extConfig, true);
+        if (!is_array($ext) || ($ext !== [] && array_is_list($ext))) {
+            throw new Exception('彩虹聚合登录扩展配置必须是有效JSON对象');
+        }
+        $type = (string)($ext['cccyun_type'] ?? '');
+        if (!in_array($type, Cccyun::SUPPORTED_TYPES, true)) {
+            throw new Exception('请选择有效的彩虹聚合登录方式');
+        }
+        $baseUrl = trim((string)($ext['cccyun_url'] ?? ''));
+        if ($baseUrl !== '') {
+            $this->validateLength($baseUrl, 1024, '彩虹聚合登录接口域名');
+            if (!preg_match('/^https:\/\/[^\s\/?#]+\/?$/i', $baseUrl)) {
+                throw new Exception('彩虹聚合登录接口域名请填写 https:// 开头的基础域名，例如 https://u.cccyun.cc/');
+            }
+            if (!$this->urlValidator->isSafeHttpsUrl(rtrim($baseUrl, '/') . '/connect.php')) {
+                throw new Exception('彩虹聚合登录接口域名不可用：请确认域名可公网解析，且不能指向内网或 localhost');
+            }
+        }
+    }
+
+    private function validateLength(string $value, int $maxLength, string $name): void
+    {
+        if (strlen($value) > $maxLength) {
+            throw new Exception($name . '长度不能超过' . $maxLength . '字节');
+        }
+    }
+
+    private function validateJson(string $value, string $name, bool $requireStringValues = false): void
+    {
+        if ($value === '') {
+            return;
+        }
+        $json = json_decode($value, true);
+        if (!is_array($json) || ($json !== [] && array_is_list($json))) {
+            throw new Exception($name . '必须是有效JSON对象');
+        }
+        if ($requireStringValues) {
+            foreach ($json as $path) {
+                if (!is_string($path) || trim($path) === '') {
+                    throw new Exception($name . '字段路径必须是非空字符串');
+                }
+                foreach (explode(',', $path) as $candidatePath) {
+                    if (trim($candidatePath) === '') {
+                        throw new Exception($name . '字段路径候选项不能为空');
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/lib/oauth/OAuthProviderFactory.php
+++ b/app/lib/oauth/OAuthProviderFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace app\lib\oauth;
+
+use Exception;
+
+class OAuthProviderFactory
+{
+    public function create(array $providerConfig): OAuthProviderInterface
+    {
+        return match ($providerConfig['type'] ?? '') {
+            'qq' => new QQ($providerConfig),
+            'github' => new GitHub($providerConfig),
+            'oauth2' => new OAuth2($providerConfig),
+            'oidc' => new OIDC($providerConfig),
+            'cccyun' => new Cccyun($providerConfig),
+            default => throw new Exception('不支持的OAuth类型: ' . ($providerConfig['type'] ?? '')),
+        };
+    }
+}

--- a/app/lib/oauth/OAuthProviderInterface.php
+++ b/app/lib/oauth/OAuthProviderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace app\lib\oauth;
+
+interface OAuthProviderInterface
+{
+    public function setRedirectUri(string $uri): void;
+
+    public function getAuthorizeUrl(string $state): string;
+
+    public function getAccessToken(string $code, string $state = ''): OAuthTokenData;
+
+    public function getUserInfo(string $accessToken): OAuthUserInfo;
+}

--- a/app/lib/oauth/OAuthTokenData.php
+++ b/app/lib/oauth/OAuthTokenData.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace app\lib\oauth;
+
+class OAuthTokenData
+{
+    public function __construct(
+        public readonly string $accessToken,
+        public readonly ?string $refreshToken = null,
+        public readonly ?int $expiresIn = null,
+        public readonly ?string $idToken = null,
+        public readonly array $raw = []
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (string)($data['access_token'] ?? ''),
+            isset($data['refresh_token']) ? (string)$data['refresh_token'] : null,
+            isset($data['expires_in']) ? (int)$data['expires_in'] : null,
+            isset($data['id_token']) ? (string)$data['id_token'] : null,
+            $data
+        );
+    }
+
+    public function toLegacyArray(): array
+    {
+        $data = $this->raw;
+        $data['access_token'] = $this->accessToken;
+        if ($this->refreshToken !== null) {
+            $data['refresh_token'] = $this->refreshToken;
+        }
+        if ($this->expiresIn !== null) {
+            $data['expires_in'] = $this->expiresIn;
+        }
+        if ($this->idToken !== null) {
+            $data['id_token'] = $this->idToken;
+        }
+        return $data;
+    }
+}

--- a/app/lib/oauth/OAuthUrlValidator.php
+++ b/app/lib/oauth/OAuthUrlValidator.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace app\lib\oauth;
+
+class OAuthUrlValidator
+{
+    public function isSafeHttpsUrl(string $url): bool
+    {
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            return false;
+        }
+        if (strtolower((string)parse_url($url, PHP_URL_SCHEME)) !== 'https') {
+            return false;
+        }
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!$host) {
+            return false;
+        }
+        return $this->resolvePublicIps($host) !== [];
+    }
+
+    public function resolvePublicIps(string $host): array
+    {
+        $host = trim($host, '[]');
+        if (in_array(strtolower($host), ['localhost', 'localhost.localdomain'], true)) {
+            return [];
+        }
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            return $this->isPrivateIp($host) ? [] : [$host];
+        }
+
+        $records = dns_get_record($host, DNS_A + DNS_AAAA);
+        if (!$records) {
+            return [];
+        }
+        $ips = [];
+        foreach ($records as $record) {
+            $ip = $record['ip'] ?? $record['ipv6'] ?? null;
+            if ($ip === null || $this->isPrivateIp($ip)) {
+                return [];
+            }
+            $ips[] = $ip;
+        }
+        return array_values(array_unique($ips));
+    }
+
+    public function isPrivateHost(string $host): bool
+    {
+        return $this->resolvePublicIps($host) === [];
+    }
+
+    private function isPrivateIp(string $ip): bool
+    {
+        return !filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+    }
+}

--- a/app/lib/oauth/OAuthUserInfo.php
+++ b/app/lib/oauth/OAuthUserInfo.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace app\lib\oauth;
+
+class OAuthUserInfo
+{
+    public function __construct(
+        public readonly string $openid,
+        public readonly string $nickname = '',
+        public readonly string $email = '',
+        public readonly string $avatar = '',
+        public readonly ?string $unionid = null,
+        public readonly ?string $rawOpenid = null,
+        public readonly array $raw = []
+    ) {}
+
+    public function withOpenid(string $openid, ?string $rawOpenid = null): self
+    {
+        return new self($openid, $this->nickname, $this->email, $this->avatar, $this->unionid, $rawOpenid, $this->raw);
+    }
+
+    public function toLegacyArray(): array
+    {
+        return [
+            'openid' => $this->openid,
+            'nickname' => $this->nickname,
+            'email' => $this->email,
+            'avatar' => $this->avatar,
+            'unionid' => $this->unionid ?? '',
+            'raw_openid' => $this->rawOpenid ?? '',
+        ];
+    }
+}

--- a/app/lib/oauth/OIDC.php
+++ b/app/lib/oauth/OIDC.php
@@ -1,0 +1,440 @@
+<?php
+
+namespace app\lib\oauth;
+
+use app\lib\OAuth;
+use Exception;
+
+class OIDC extends OAuth
+{
+    private ?array $discovery = null;
+    private array $tokenData = [];
+
+    private function discover(): array
+    {
+        if ($this->discovery !== null) {
+            return $this->discovery;
+        }
+        $issuer = rtrim((string)$this->config['oidc_issuer'], '/');
+        $urlValidator = new OAuthUrlValidator();
+        if (!$urlValidator->isSafeHttpsUrl($issuer)) {
+            throw new Exception('OIDC Issuer URL必须使用安全的HTTPS公网地址');
+        }
+        $url = $issuer . '/.well-known/openid-configuration';
+        $data = $this->jsonGet($url);
+        if (empty($data['authorization_endpoint']) || empty($data['token_endpoint']) || empty($data['jwks_uri'])) {
+            throw new Exception('OIDC自动发现失败');
+        }
+        if (empty($data['issuer']) || rtrim((string)$data['issuer'], '/') !== rtrim((string)$this->config['oidc_issuer'], '/')) {
+            throw new Exception('OIDC discovery issuer验证失败');
+        }
+        foreach (['authorization_endpoint', 'token_endpoint', 'jwks_uri'] as $field) {
+            if (!$urlValidator->isSafeHttpsUrl($data[$field])) {
+                throw new Exception('OIDC自动发现端点必须使用安全的HTTPS公网地址');
+            }
+        }
+        if (!empty($data['userinfo_endpoint']) && !$urlValidator->isSafeHttpsUrl($data['userinfo_endpoint'])) {
+            throw new Exception('OIDC自动发现端点必须使用安全的HTTPS公网地址');
+        }
+        $this->discovery = $data;
+        return $data;
+    }
+
+    public function getAuthorizeUrl(string $state): string
+    {
+        $discovery = $this->discover();
+        $nonce = bin2hex(random_bytes(16));
+        $verifier = $this->createPkceVerifier($state);
+        $this->setState($state);
+        $this->saveNonce($state, $nonce);
+        $params = http_build_query([
+            'response_type' => 'code',
+            'client_id' => $this->config['client_id'],
+            'redirect_uri' => $this->redirectUri,
+            'state' => $state,
+            'scope' => $this->config['scopes'] ?: 'openid profile email',
+            'nonce' => $nonce,
+            'code_challenge' => $this->createPkceChallenge($verifier),
+            'code_challenge_method' => 'S256',
+        ]);
+        return $this->appendQuery($discovery['authorization_endpoint'], $params);
+    }
+
+    public function getAccessToken(string $code, string $state = ''): OAuthTokenData
+    {
+        $this->setState($state);
+        $discovery = $this->discover();
+        $data = $this->jsonPost($discovery['token_endpoint'], [
+            'grant_type' => 'authorization_code',
+            'client_id' => $this->config['client_id'],
+            'client_secret' => $this->config['client_secret'],
+            'code' => $code,
+            'redirect_uri' => $this->redirectUri,
+            'code_verifier' => $this->consumePkceVerifier($state),
+        ], [
+            'Accept' => 'application/json',
+        ]);
+
+        if (empty($data['access_token'])) {
+            throw new Exception('OIDC获取access_token失败');
+        }
+        $this->tokenData = $data;
+        return OAuthTokenData::fromArray($data);
+    }
+
+    public function getUserInfo(string $accessToken): OAuthUserInfo
+    {
+        $discovery = $this->discover();
+        if (empty($this->tokenData['id_token'])) {
+            throw new Exception('OIDC缺少id_token，无法验证nonce');
+        }
+
+        $userData = [];
+        if (!empty($discovery['userinfo_endpoint'])) {
+            $headers = [
+                'Authorization' => 'Bearer ' . $accessToken,
+                'Accept' => 'application/json',
+            ];
+            $userData = $this->jsonGet($discovery['userinfo_endpoint'], $headers);
+        }
+
+        $userinfoSub = (string)($userData['sub'] ?? '');
+        $jwt = $this->verifyIdToken($this->tokenData['id_token'], $discovery, $userinfoSub);
+        $sub = (string)$jwt['sub'];
+        $openid = hash('sha256', rtrim((string)$discovery['issuer'], '/') . "\n" . $sub);
+
+        return new OAuthUserInfo(
+            $openid,
+            $userData['nickname'] ?? $userData['preferred_username'] ?? $userData['name'] ?? ($jwt['nickname'] ?? $jwt['preferred_username'] ?? $jwt['name'] ?? ''),
+            $userData['email'] ?? ($jwt['email'] ?? ''),
+            $userData['picture'] ?? ($jwt['picture'] ?? ''),
+            null,
+            null,
+            ['userinfo' => $userData, 'id_token_payload' => $jwt, 'oidc_sub' => $sub, 'oidc_issuer' => rtrim((string)$discovery['issuer'], '/')]
+        );
+    }
+
+    private function verifyIdToken(string $idToken, array $discovery, string $userinfoSub): array
+    {
+        [$header, $payload, $signature, $signedData] = $this->parseJwt($idToken);
+        if (empty($header['alg'])) {
+            throw new Exception('OIDC id_token格式不正确');
+        }
+        if (!in_array($header['alg'], ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512'], true)) {
+            throw new Exception('OIDC id_token签名算法不受支持');
+        }
+
+        $jwks = $this->jsonGet($discovery['jwks_uri']);
+        $key = $this->findJwk($jwks['keys'] ?? [], (string)($header['kid'] ?? ''), $header['alg']);
+        if (!$key || !$this->verifyJwtSignature($header['alg'], $signedData, $signature, $key)) {
+            throw new Exception('OIDC id_token签名验证失败');
+        }
+
+        $this->validateClaims($payload, $discovery, $userinfoSub);
+        return $payload;
+    }
+
+    private function parseJwt(string $jwt): array
+    {
+        $parts = explode('.', $jwt);
+        if (count($parts) !== 3) {
+            throw new Exception('OIDC id_token格式不正确');
+        }
+        $header = $this->jsonDecodeBase64Url($parts[0]);
+        $payload = $this->jsonDecodeBase64Url($parts[1]);
+        $signature = $this->base64UrlDecode($parts[2]);
+        return [$header, $payload, $signature, $parts[0] . '.' . $parts[1]];
+    }
+
+    private function validateClaims(array $payload, array $discovery, string $userinfoSub): void
+    {
+        $issuer = rtrim((string)($discovery['issuer'] ?? $this->config['oidc_issuer']), '/');
+        if (empty($payload['iss']) || rtrim((string)$payload['iss'], '/') !== $issuer) {
+            throw new Exception('OIDC issuer验证失败');
+        }
+
+        $audiences = is_array($payload['aud'] ?? null) ? $payload['aud'] : [$payload['aud'] ?? null];
+        if (!in_array($this->config['client_id'], $audiences, true)) {
+            throw new Exception('OIDC audience验证失败');
+        }
+        if (count($audiences) > 1 && (($payload['azp'] ?? '') !== $this->config['client_id'])) {
+            throw new Exception('OIDC azp验证失败');
+        }
+
+        $now = time();
+        if (empty($payload['exp']) || (int)$payload['exp'] < $now) {
+            throw new Exception('OIDC id_token已过期');
+        }
+        if (!empty($payload['nbf']) && (int)$payload['nbf'] > $now + 60) {
+            throw new Exception('OIDC id_token尚未生效');
+        }
+        if (!empty($payload['iat']) && (int)$payload['iat'] > $now + 60) {
+            throw new Exception('OIDC id_token签发时间无效');
+        }
+
+        $savedNonce = $this->consumeNonce();
+        if (empty($savedNonce)) {
+            throw new Exception('OIDC nonce不存在，请重新登录');
+        }
+        if (empty($payload['nonce']) || !hash_equals((string)$savedNonce, (string)$payload['nonce'])) {
+            throw new Exception('OIDC nonce验证失败');
+        }
+        if (empty($payload['sub'])) {
+            throw new Exception('OIDC用户标识验证失败');
+        }
+        if ($userinfoSub !== '' && !hash_equals((string)$payload['sub'], $userinfoSub)) {
+            throw new Exception('OIDC用户标识验证失败');
+        }
+    }
+
+    private function appendQuery(string $url, string $query): string
+    {
+        return $url . (str_contains($url, '?') ? '&' : '?') . $query;
+    }
+
+    private function saveNonce(string $state, string $nonce): void
+    {
+        $nonceMap = session('oidc_nonce_map') ?: [];
+        if (!is_array($nonceMap)) {
+            $nonceMap = [];
+        }
+        $now = time();
+        foreach ($nonceMap as $key => $value) {
+            if (!is_array($value) || (int)($value['expires_at'] ?? 0) < $now) {
+                unset($nonceMap[$key]);
+            }
+        }
+        $nonceMap[$state] = ['nonce' => $nonce, 'expires_at' => $now + 600];
+        session('oidc_nonce_map', $nonceMap);
+    }
+
+    private function consumeNonce(): string
+    {
+        if ($this->state === '') {
+            return '';
+        }
+        $nonceMap = session('oidc_nonce_map') ?: [];
+        if (!is_array($nonceMap) || empty($nonceMap[$this->state]) || !is_array($nonceMap[$this->state])) {
+            return '';
+        }
+        $entry = $nonceMap[$this->state];
+        unset($nonceMap[$this->state]);
+        session('oidc_nonce_map', $nonceMap);
+        if ((int)($entry['expires_at'] ?? 0) < time()) {
+            return '';
+        }
+        return (string)($entry['nonce'] ?? '');
+    }
+
+    private function findJwk(array $keys, string $kid, string $alg): ?array
+    {
+        $matches = [];
+        foreach ($keys as $key) {
+            if (!$this->isJwkAllowedForAlg($key, $alg)) {
+                continue;
+            }
+            if ($kid !== '') {
+                if (($key['kid'] ?? '') === $kid) {
+                    return $key;
+                }
+                continue;
+            }
+            $matches[] = $key;
+        }
+        return count($matches) === 1 ? $matches[0] : null;
+    }
+
+    private function isJwkAllowedForAlg(array $key, string $alg): bool
+    {
+        if (!empty($key['alg']) && $key['alg'] !== $alg) {
+            return false;
+        }
+        if (!empty($key['use']) && $key['use'] !== 'sig') {
+            return false;
+        }
+        if (!empty($key['key_ops']) && (!is_array($key['key_ops']) || !in_array('verify', $key['key_ops'], true))) {
+            return false;
+        }
+        if (str_starts_with($alg, 'RS')) {
+            return ($key['kty'] ?? '') === 'RSA' && !empty($key['n']) && !empty($key['e']);
+        }
+        $expectedCurve = match ($alg) {
+            'ES256' => 'P-256',
+            'ES384' => 'P-384',
+            'ES512' => 'P-521',
+            default => '',
+        };
+        return $expectedCurve !== ''
+            && ($key['kty'] ?? '') === 'EC'
+            && ($key['crv'] ?? '') === $expectedCurve
+            && !empty($key['x'])
+            && !empty($key['y']);
+    }
+
+    private function verifyJwtSignature(string $alg, string $signedData, string $signature, array $key): bool
+    {
+        $publicKey = $this->buildPublicKey($key);
+        if ($publicKey === '') {
+            return false;
+        }
+        if (str_starts_with($alg, 'ES')) {
+            $signature = $this->joseToDerSignature($signature, $alg);
+        }
+        $result = @openssl_verify($signedData, $signature, $publicKey, $this->opensslAlgorithm($alg));
+        if ($result === false) {
+            throw new Exception('OIDC id_token签名验证失败：当前 PHP OpenSSL 不支持 ' . $alg . ' 签名算法');
+        }
+        return $result === 1;
+    }
+
+    private function buildPublicKey(array $key): string
+    {
+        if (($key['kty'] ?? '') === 'RSA' && !empty($key['n']) && !empty($key['e'])) {
+            return $this->rsaPublicKeyFromComponents($this->base64UrlDecode($key['n']), $this->base64UrlDecode($key['e']));
+        }
+        if (($key['kty'] ?? '') === 'EC' && !empty($key['crv']) && !empty($key['x']) && !empty($key['y'])) {
+            return $this->ecPublicKeyFromComponents($key['crv'], $this->base64UrlDecode($key['x']), $this->base64UrlDecode($key['y']));
+        }
+        return '';
+    }
+
+    private function rsaPublicKeyFromComponents(string $modulus, string $exponent): string
+    {
+        $sequence = $this->asn1Sequence(
+            $this->asn1Integer($modulus) .
+            $this->asn1Integer($exponent)
+        );
+        $bitString = $this->asn1BitString($sequence);
+        $algorithm = $this->asn1Sequence(
+            $this->asn1ObjectIdentifier('1.2.840.113549.1.1.1') .
+            $this->asn1Null()
+        );
+        return $this->pemEncode($this->asn1Sequence($algorithm . $bitString), 'PUBLIC KEY');
+    }
+
+    private function ecPublicKeyFromComponents(string $curve, string $x, string $y): string
+    {
+        $curveOid = match ($curve) {
+            'P-256' => '1.2.840.10045.3.1.7',
+            'P-384' => '1.3.132.0.34',
+            'P-521' => '1.3.132.0.35',
+            default => '',
+        };
+        if ($curveOid === '') {
+            return '';
+        }
+        $algorithm = $this->asn1Sequence(
+            $this->asn1ObjectIdentifier('1.2.840.10045.2.1') .
+            $this->asn1ObjectIdentifier($curveOid)
+        );
+        return $this->pemEncode($this->asn1Sequence($algorithm . $this->asn1BitString("\x04" . $x . $y)), 'PUBLIC KEY');
+    }
+
+    private function joseToDerSignature(string $signature, string $alg): string
+    {
+        $expectedLength = match ($alg) {
+            'ES256' => 64,
+            'ES384' => 96,
+            'ES512' => 132,
+            default => 0,
+        };
+        if ($expectedLength === 0 || strlen($signature) !== $expectedLength) {
+            throw new Exception('OIDC ECDSA签名长度无效');
+        }
+        $length = intdiv($expectedLength, 2);
+        return $this->asn1Sequence(
+            $this->asn1Integer(substr($signature, 0, $length)) .
+            $this->asn1Integer(substr($signature, $length))
+        );
+    }
+
+    private function opensslAlgorithm(string $alg): string
+    {
+        return match ($alg) {
+            'RS256', 'ES256' => 'sha256',
+            'RS384', 'ES384' => 'sha384',
+            'RS512', 'ES512' => 'sha512',
+            default => 'sha256',
+        };
+    }
+
+    private function jsonDecodeBase64Url(string $value): array
+    {
+        $data = json_decode($this->base64UrlDecode($value), true);
+        if (!is_array($data)) {
+            throw new Exception('OIDC id_token格式不正确');
+        }
+        return $data;
+    }
+
+    private function base64UrlDecode(string $value): string
+    {
+        $value .= str_repeat('=', (4 - strlen($value) % 4) % 4);
+        $decoded = base64_decode(strtr($value, '-_', '+/'), true);
+        if ($decoded === false) {
+            throw new Exception('OIDC id_token格式不正确');
+        }
+        return $decoded;
+    }
+
+    private function asn1Sequence(string $value): string
+    {
+        return "\x30" . $this->asn1Length(strlen($value)) . $value;
+    }
+
+    private function asn1Integer(string $value): string
+    {
+        $value = ltrim($value, "\x00");
+        if ($value === '') {
+            $value = "\x00";
+        }
+        if ((ord($value[0]) & 0x80) !== 0) {
+            $value = "\x00" . $value;
+        }
+        return "\x02" . $this->asn1Length(strlen($value)) . $value;
+    }
+
+    private function asn1BitString(string $value): string
+    {
+        return "\x03" . $this->asn1Length(strlen($value) + 1) . "\x00" . $value;
+    }
+
+    private function asn1Null(): string
+    {
+        return "\x05\x00";
+    }
+
+    private function asn1ObjectIdentifier(string $oid): string
+    {
+        $parts = array_map('intval', explode('.', $oid));
+        $body = chr($parts[0] * 40 + $parts[1]);
+        foreach (array_slice($parts, 2) as $part) {
+            $bytes = [chr($part & 0x7f)];
+            $part >>= 7;
+            while ($part > 0) {
+                array_unshift($bytes, chr(($part & 0x7f) | 0x80));
+                $part >>= 7;
+            }
+            $body .= implode('', $bytes);
+        }
+        return "\x06" . $this->asn1Length(strlen($body)) . $body;
+    }
+
+    private function asn1Length(int $length): string
+    {
+        if ($length < 128) {
+            return chr($length);
+        }
+        $bytes = '';
+        while ($length > 0) {
+            $bytes = chr($length & 0xff) . $bytes;
+            $length >>= 8;
+        }
+        return chr(0x80 | strlen($bytes)) . $bytes;
+    }
+
+    private function pemEncode(string $der, string $label): string
+    {
+        return "-----BEGIN {$label}-----\n" . chunk_split(base64_encode($der), 64, "\n") . "-----END {$label}-----\n";
+    }
+}

--- a/app/lib/oauth/QQ.php
+++ b/app/lib/oauth/QQ.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace app\lib\oauth;
+
+use app\lib\OAuth;
+use Exception;
+
+class QQ extends OAuth
+{
+    private function getExtConfig(): array
+    {
+        if (!empty($this->config['ext_config'])) {
+            $ext = json_decode($this->config['ext_config'], true);
+            if (is_array($ext)) {
+                return $ext;
+            }
+        }
+        return [];
+    }
+
+    public function getAuthorizeUrl(string $state): string
+    {
+        $scopes = $this->config['scopes'] ?: 'get_user_info';
+        $ext = $this->getExtConfig();
+        if (!empty($ext['unionid'])) {
+            $scopes .= ' unionid';
+        }
+        $verifier = $this->createPkceVerifier($state);
+        $params = http_build_query([
+            'response_type' => 'code',
+            'client_id' => $this->config['client_id'],
+            'redirect_uri' => $this->redirectUri,
+            'state' => $state,
+            'scope' => $scopes,
+            'code_challenge' => $this->createPkceChallenge($verifier),
+            'code_challenge_method' => 'S256',
+        ]);
+        return 'https://graph.qq.com/oauth2.0/authorize?' . $params;
+    }
+
+    public function getAccessToken(string $code, string $state = ''): OAuthTokenData
+    {
+        $params = [
+            'grant_type' => 'authorization_code',
+            'client_id' => $this->config['client_id'],
+            'client_secret' => $this->config['client_secret'],
+            'code' => $code,
+            'redirect_uri' => $this->redirectUri,
+            'fmt' => 'json',
+            'code_verifier' => $this->consumePkceVerifier($state),
+        ];
+        $resp = $this->httpGet('https://graph.qq.com/oauth2.0/token?' . http_build_query($params));
+
+        $data = json_decode($resp['body'], true);
+        if (!is_array($data)) {
+            parse_str($resp['body'], $data);
+        }
+        if (!empty($data['access_token'])) {
+            return OAuthTokenData::fromArray($data);
+        }
+        if (!empty($data['error'])) {
+            throw new Exception('QQ登录授权失败：' . ($data['error_description'] ?? $data['msg'] ?? $data['error']));
+        }
+
+        throw new Exception('QQ登录授权失败：未获取到访问令牌，请重新发起登录');
+    }
+
+    public function getUserInfo(string $accessToken): OAuthUserInfo
+    {
+        $ext = $this->getExtConfig();
+        $useUnionid = !empty($ext['unionid']);
+
+        $meUrl = 'https://graph.qq.com/oauth2.0/me?access_token=' . urlencode($accessToken) . '&fmt=json';
+        if ($useUnionid) {
+            $meUrl .= '&unionid=1';
+        }
+        $openidResp = $this->httpGet($meUrl);
+        $openidData = json_decode($openidResp['body'], true);
+        if (empty($openidData['openid']) && preg_match('/callback\s*\(\s*(.*?)\s*\)\s*;?\s*$/s', $openidResp['body'], $matches)) {
+            $openidData = json_decode($matches[1], true);
+        }
+        if (!is_array($openidData)) {
+            throw new Exception('QQ登录返回数据异常，请重新发起登录');
+        }
+        if (!empty($openidData['error'])) {
+            throw new Exception('QQ登录授权失败：' . ($openidData['error_description'] ?? $openidData['msg'] ?? $openidData['error']));
+        }
+        if (empty($openidData['openid'])) {
+            throw new Exception('QQ登录授权已过期，请重新发起登录');
+        }
+        $openid = (string)$openidData['openid'];
+        $unionid = isset($openidData['unionid']) ? (string)$openidData['unionid'] : null;
+
+        $params = http_build_query([
+            'access_token' => $accessToken,
+            'oauth_consumer_key' => $this->config['client_id'],
+            'openid' => $openid,
+        ]);
+        $userData = $this->jsonGet('https://graph.qq.com/user/get_user_info?' . $params);
+
+        if (!isset($userData['ret'])) {
+            throw new Exception('QQ登录获取用户信息失败：返回数据缺少状态码');
+        }
+        if ((int)$userData['ret'] !== 0) {
+            throw new Exception('QQ登录获取用户信息失败：' . ($userData['msg'] ?? '请确认应用已开通 get_user_info 权限'));
+        }
+
+        return new OAuthUserInfo(
+            $openid,
+            $userData['nickname'] ?? '',
+            '',
+            ($userData['figureurl_qq_2'] ?? '') ?: ($userData['figureurl_qq_1'] ?? ''),
+            $unionid,
+            null,
+            ['openid' => $openidData, 'user' => $userData]
+        );
+    }
+}

--- a/app/service/oauth/OAuthAuthService.php
+++ b/app/service/oauth/OAuthAuthService.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace app\service\oauth;
+
+use app\lib\OAuth;
+use app\lib\oauth\OAuthTokenData;
+use app\lib\oauth\OAuthUserInfo;
+use Exception;
+use think\facade\Db;
+
+class OAuthAuthService
+{
+    public function __construct(
+        private ?OAuthSessionStore $sessionStore = null,
+        private ?OAuthTokenStore $tokenStore = null
+    ) {
+        $this->sessionStore = $sessionStore ?: new OAuthSessionStore();
+        $this->tokenStore = $tokenStore ?: new OAuthTokenStore();
+    }
+
+    public function buildLoginRedirect(int $providerId, string $callbackUrl): string
+    {
+        $provider = $this->getEnabledProvider($providerId);
+        $oauth = OAuth::create($provider);
+        $oauth->setRedirectUri($callbackUrl);
+        $state = bin2hex(random_bytes(16));
+        $this->sessionStore->startLogin($state, $providerId, $callbackUrl);
+        return $oauth->getAuthorizeUrl($state);
+    }
+
+    public function buildBindRedirect(int $providerId, int $userId, string $callbackUrl): string
+    {
+        $provider = $this->getEnabledProvider($providerId);
+        $oauth = OAuth::create($provider);
+        $oauth->setRedirectUri($callbackUrl);
+        $state = bin2hex(random_bytes(16));
+        $this->sessionStore->startBind($state, $providerId, $userId, $callbackUrl);
+        return $oauth->getAuthorizeUrl($state);
+    }
+
+    public function handleCallback(int $providerId, string $code, string $state, string $callbackUrl, ?int $currentUserId = null): array
+    {
+        [$flow, $bindUserId] = $this->sessionStore->consumeFlow($state, $providerId, $callbackUrl);
+        if ($flow === 'bind' && ($currentUserId === null || $currentUserId !== $bindUserId)) {
+            throw new Exception('绑定登录态已变化，请重新登录后再绑定');
+        }
+        $provider = $this->getEnabledProvider($providerId);
+        $oauth = OAuth::create($provider);
+        $oauth->setRedirectUri($callbackUrl);
+        $tokenData = $oauth->getAccessToken($code, $state);
+        $userInfo = $this->normalizeUserInfo($oauth->getUserInfo($tokenData->accessToken));
+        if ($userInfo->openid === '') {
+            throw new Exception('获取用户标识失败');
+        }
+
+        if ($flow === 'bind') {
+            $bindResult = $this->bindUser($provider, $userInfo, $tokenData, $bindUserId);
+            if ($bindResult !== null) {
+                return $bindResult;
+            }
+            return ['type' => 'alert', 'level' => 'success', 'msg' => '绑定' . $provider['name'] . '账号成功！', 'url' => '/user/center'];
+        }
+
+        $user = $this->loginByOAuth($provider, $userInfo, $tokenData);
+        return [
+            'type' => 'login',
+            'user' => $user,
+            'provider' => $provider,
+            'userInfo' => $userInfo,
+            'tokenData' => $tokenData,
+            'requiresTotp' => !empty($user['totp_open']) && !empty($user['totp_secret']),
+        ];
+    }
+
+    public function updateLoginBinding(array $provider, OAuthUserInfo $userInfo, OAuthTokenData $tokenData): void
+    {
+        $binding = Db::name('user_oauth')
+            ->where('provider_id', $provider['id'])
+            ->where('openid', $userInfo->openid)
+            ->find();
+        if (!$binding && !empty($userInfo->rawOpenid)) {
+            $binding = Db::name('user_oauth')
+                ->where('provider_id', $provider['id'])
+                ->where('openid', $userInfo->rawOpenid)
+                ->find();
+        }
+        if (!$binding) {
+            throw new Exception('该第三方账号尚未绑定本站账号，请先使用可用登录方式进入用户中心绑定；如无法登录，请联系管理员');
+        }
+        $updateData = ['openid' => $userInfo->openid] + $this->buildBindingData($userInfo, $tokenData, false);
+        Db::name('user_oauth')->where('id', $binding['id'])->update($updateData);
+    }
+
+    public function unbind(int $userId, int $providerId): void
+    {
+        Db::transaction(function () use ($userId, $providerId) {
+            $record = Db::name('user_oauth')
+                ->where('user_id', $userId)
+                ->where('provider_id', $providerId)
+                ->lock(true)
+                ->find();
+            if (!$record) {
+                throw new Exception('未绑定该提供商');
+            }
+
+            if (config_get('oauth_disable_password', '0') == '1') {
+                $remaining = Db::name('user_oauth')->alias('uo')
+                    ->join('oauth_provider op', 'op.id = uo.provider_id')
+                    ->where('uo.user_id', $userId)
+                    ->where('uo.id', '<>', $record['id'])
+                    ->where('op.enabled', 1)
+                    ->lock(true)
+                    ->count();
+                if ($remaining == 0) {
+                    throw new Exception('密码登录已禁用，不能解绑最后一个可用的第三方登录');
+                }
+            }
+
+            Db::name('user_oauth')->where('id', $record['id'])->delete();
+            Db::name('log')->insert([
+                'uid' => $userId,
+                'action' => '解绑OAuth',
+                'data' => 'ProviderID:' . $providerId . ', OpenIDHash:' . $this->hashOAuthIdentifier((string)$record['openid']),
+                'addtime' => date('Y-m-d H:i:s'),
+            ]);
+        });
+    }
+
+    private function getEnabledProvider(int $providerId): array
+    {
+        $provider = Db::name('oauth_provider')->where('id', $providerId)->where('enabled', 1)->find();
+        if (!$provider) {
+            throw new Exception('OAuth提供商不存在或已禁用');
+        }
+        return $provider;
+    }
+
+    private function normalizeUserInfo(OAuthUserInfo $userInfo): OAuthUserInfo
+    {
+        if (!empty($userInfo->unionid)) {
+            return $userInfo->withOpenid($userInfo->unionid, $userInfo->openid);
+        }
+        return $userInfo;
+    }
+
+    private function loginByOAuth(array $provider, OAuthUserInfo $userInfo, OAuthTokenData $tokenData): array
+    {
+        $binding = Db::name('user_oauth')
+            ->where('provider_id', $provider['id'])
+            ->where('openid', $userInfo->openid)
+            ->find();
+        if (!$binding && !empty($userInfo->rawOpenid)) {
+            $binding = Db::name('user_oauth')
+                ->where('provider_id', $provider['id'])
+                ->where('openid', $userInfo->rawOpenid)
+                ->find();
+        }
+
+        if (!$binding) {
+            throw new Exception('该第三方账号尚未绑定本站账号，请先使用可用登录方式进入用户中心绑定；如无法登录，请联系管理员');
+        }
+
+        $user = Db::name('user')->where('id', $binding['user_id'])->find();
+        if (!$user || $user['status'] != 1) {
+            throw new Exception('绑定的账号不存在或已被封禁');
+        }
+
+        return $user;
+    }
+
+    private function bindUser(array $provider, OAuthUserInfo $userInfo, OAuthTokenData $tokenData, int $userId): ?array
+    {
+        if ($userId <= 0) {
+            throw new Exception('绑定用户信息已失效，请重新登录');
+        }
+        $user = Db::name('user')->where('id', $userId)->find();
+        if (!$user || $user['status'] != 1) {
+            throw new Exception('绑定用户不存在或已被禁用，请重新登录');
+        }
+        $openids = [$userInfo->openid];
+        if (!empty($userInfo->rawOpenid)) {
+            $openids[] = $userInfo->rawOpenid;
+        }
+        $existing = Db::name('user_oauth')
+            ->where('provider_id', $provider['id'])
+            ->whereIn('openid', array_values(array_unique($openids)))
+            ->find();
+
+        if ($existing) {
+            if ($existing['user_id'] == $userId) {
+                return ['type' => 'alert', 'level' => 'warning', 'msg' => '该账号已绑定此' . $provider['name'] . '账号，无需重复绑定', 'url' => '/user/center'];
+            }
+            throw new Exception('该' . $provider['name'] . '账号已被其他用户绑定');
+        }
+
+        $userProviderBinding = Db::name('user_oauth')
+            ->where('user_id', $userId)
+            ->where('provider_id', $provider['id'])
+            ->find();
+        if ($userProviderBinding) {
+            throw new Exception('该用户已绑定此' . $provider['name'] . '提供商，请先解绑后再绑定');
+        }
+
+        $insertData = [
+            'user_id' => $userId,
+            'provider_id' => $provider['id'],
+            'openid' => $userInfo->openid,
+        ] + $this->buildBindingData($userInfo, $tokenData, true);
+
+        try {
+            Db::name('user_oauth')->insert($insertData);
+        } catch (Exception $e) {
+            if (stripos($e->getMessage(), 'uk_user_provider') !== false) {
+                throw new Exception('该用户已绑定此' . $provider['name'] . '提供商，请先解绑后再绑定');
+            }
+            if (stripos($e->getMessage(), 'uk_provider_openid') !== false || stripos($e->getMessage(), 'Duplicate') !== false) {
+                throw new Exception('该' . $provider['name'] . '账号已被其他用户绑定');
+            }
+            throw $e;
+        }
+
+        Db::name('log')->insert([
+            'uid' => $userId,
+            'action' => '绑定OAuth',
+            'data' => 'Provider:' . $provider['name'] . ', OpenIDHash:' . $this->hashOAuthIdentifier($userInfo->openid),
+            'addtime' => date('Y-m-d H:i:s'),
+        ]);
+
+        return null;
+    }
+
+    private function hashOAuthIdentifier(string $identifier): string
+    {
+        return substr(hash('sha256', $identifier), 0, 16);
+    }
+
+    private function buildBindingData(OAuthUserInfo $userInfo, OAuthTokenData $tokenData, bool $includeAddtime): array
+    {
+        $now = date('Y-m-d H:i:s');
+        $data = [
+            'nickname' => $userInfo->nickname,
+            'email' => $userInfo->email,
+            'avatar' => $userInfo->avatar,
+            'lasttime' => $now,
+        ] + $this->tokenStore->buildSaveData($tokenData);
+        if ($includeAddtime) {
+            $data['addtime'] = $now;
+        }
+        return $data;
+    }
+}

--- a/app/service/oauth/OAuthProviderService.php
+++ b/app/service/oauth/OAuthProviderService.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace app\service\oauth;
+
+use app\lib\oauth\OAuthProviderConfigValidator;
+use Exception;
+use think\facade\Db;
+
+class OAuthProviderService
+{
+    private array $sortFields = ['id', 'name', 'type', 'enabled', 'sort', 'addtime'];
+
+    public function list(int $offset, int $limit, string $sort, string $order): array
+    {
+        $sort = in_array($sort, $this->sortFields, true) ? $sort : 'sort';
+        $order = strtolower($order) === 'desc' ? 'desc' : 'asc';
+        $query = Db::name('oauth_provider');
+        $total = $query->count();
+        $rows = Db::name('oauth_provider')->order($sort, $order)->limit($offset, $limit)->select()->toArray();
+        foreach ($rows as &$row) {
+            $row = $this->redactSecret($row);
+        }
+        unset($row);
+        return ['total' => $total, 'rows' => $rows];
+    }
+
+    public function get(int $id): array
+    {
+        $row = Db::name('oauth_provider')->where('id', $id)->find();
+        if (!$row) {
+            throw new Exception('提供商不存在');
+        }
+        return $this->redactSecret($row);
+    }
+
+    public function save(array $data, bool $isEdit, int $id = 0): void
+    {
+        if ($isEdit && $id <= 0) {
+            throw new Exception('参数错误');
+        }
+        $provider = null;
+        if ($isEdit) {
+            $provider = $this->getRaw($id);
+        }
+        $data = (new OAuthProviderConfigValidator())->validate($data, $isEdit);
+        if (in_array($data['type'], ['qq', 'cccyun'], true)) {
+            $data['scopes'] = '';
+        }
+        $data['logo'] = $this->validateLogo((string)($data['logo'] ?? ''));
+        if ($isEdit && empty($data['client_secret'])) {
+            unset($data['client_secret']);
+        }
+
+        if ($isEdit) {
+            Db::transaction(function () use ($id, $data, $provider) {
+                if (config_get('oauth_disable_password', '0') == '1' && $provider && $provider['enabled'] == 1) {
+                    $lockedProvider = Db::name('oauth_provider')->where('id', $id)->lock(true)->find();
+                    if (!$lockedProvider) {
+                        throw new Exception('提供商不存在');
+                    }
+                    $excludeId = (isset($data['enabled']) && (int)$data['enabled'] === 0) ? $id : 0;
+                    if (!$this->hasAdminOauthBinding($excludeId, true)) {
+                        throw new Exception('密码登录已禁用，至少需要保留一个超级管理员可用的OAuth绑定');
+                    }
+                    if ($this->isCriticalChange($lockedProvider, $data) && !$this->hasAdminOauthBinding($id, true)) {
+                        throw new Exception('密码登录已禁用，不能修改最后一个超级管理员可用OAuth提供商的关键配置');
+                    }
+                }
+                Db::name('oauth_provider')->where('id', $id)->update($data);
+            });
+            return;
+        }
+        $data['addtime'] = date('Y-m-d H:i:s');
+        Db::name('oauth_provider')->insert($data);
+    }
+
+    public function delete(int $id): void
+    {
+        Db::transaction(function () use ($id) {
+            $provider = Db::name('oauth_provider')->where('id', $id)->lock(true)->find();
+            if (!$provider) {
+                throw new Exception('提供商不存在');
+            }
+            if (config_get('oauth_disable_password', '0') == '1') {
+                if ($provider['enabled'] == 1 && !$this->hasAdminOauthBinding($id, true)) {
+                    throw new Exception('密码登录已禁用，至少需要保留一个超级管理员可用的OAuth绑定');
+                }
+            }
+            Db::name('oauth_provider')->where('id', $id)->delete();
+            Db::name('user_oauth')->where('provider_id', $id)->delete();
+        });
+    }
+
+    public function hasAdminOauthBinding(int $excludeProviderId = 0, bool $lock = false, int $excludeUserId = 0): bool
+    {
+        $query = Db::name('user_oauth')->alias('uo')
+            ->join('user u', 'u.id = uo.user_id')
+            ->join('oauth_provider op', 'op.id = uo.provider_id')
+            ->where('u.status', 1)
+            ->where('u.level', 2)
+            ->where('op.enabled', 1);
+        if ($excludeProviderId > 0) {
+            $query->where('op.id', '<>', $excludeProviderId);
+        }
+        if ($excludeUserId > 0) {
+            $query->where('u.id', '<>', $excludeUserId);
+        }
+        if ($lock) {
+            $query->lock(true);
+        }
+        return $query->count() > 0;
+    }
+
+    public function getEnabledProviders(): array
+    {
+        $providers = Db::name('oauth_provider')
+            ->where('enabled', 1)
+            ->order('sort', 'asc')
+            ->select()
+            ->toArray();
+        foreach ($providers as &$provider) {
+            $provider = $this->redactSecret($provider);
+        }
+        unset($provider);
+        return $providers;
+    }
+
+    public function getEnabledProvidersWithUserBindings(int $userId): array
+    {
+        $providers = $this->getEnabledProviders();
+        $bindings = Db::name('user_oauth')
+            ->where('user_id', $userId)
+            ->select();
+        $boundMap = [];
+        foreach ($bindings as $binding) {
+            $displayName = $binding['nickname'] ?: ($binding['email'] ?: $binding['openid']);
+            $boundMap[$binding['provider_id']] = [
+                'display_name' => $displayName,
+                'avatar' => $binding['avatar'] ?: '',
+            ];
+        }
+        foreach ($providers as &$provider) {
+            if (isset($boundMap[$provider['id']])) {
+                $provider['bind_display_name'] = $boundMap[$provider['id']]['display_name'];
+                $provider['bind_avatar'] = $boundMap[$provider['id']]['avatar'];
+            }
+        }
+        unset($provider);
+        return $providers;
+    }
+
+    private function getRaw(int $id): array
+    {
+        $row = Db::name('oauth_provider')->where('id', $id)->find();
+        if (!$row) {
+            throw new Exception('提供商不存在');
+        }
+        return $row;
+    }
+
+    private function redactSecret(array $row): array
+    {
+        $row['client_secret'] = '';
+        return $row;
+    }
+
+    private function validateLogo(string $logo): string
+    {
+        if ($logo === '') {
+            return '';
+        }
+        if (str_starts_with($logo, 'fa-')) {
+            if (!preg_match('/^fa-[a-z0-9-]{1,64}$/i', $logo)) {
+                throw new Exception('Logo 图标类名格式不正确');
+            }
+            return $logo;
+        }
+        $parts = parse_url($logo);
+        if (($parts['scheme'] ?? '') !== 'https' || empty($parts['host']) || strlen($logo) > 255) {
+            throw new Exception('Logo URL 必须是长度不超过 255 的 HTTPS 地址');
+        }
+        return $logo;
+    }
+
+    private function isCriticalChange(array $provider, array $data): bool
+    {
+        foreach (['type', 'client_id', 'oauth_authorize_url', 'oauth_token_url', 'oauth_userinfo_url', 'oidc_issuer', 'scopes', 'userinfo_fields', 'ext_config'] as $field) {
+            if ((string)($provider[$field] ?? '') !== (string)($data[$field] ?? '')) {
+                return true;
+            }
+        }
+        return !empty($data['client_secret']);
+    }
+}

--- a/app/service/oauth/OAuthSessionStore.php
+++ b/app/service/oauth/OAuthSessionStore.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace app\service\oauth;
+
+use Exception;
+
+class OAuthSessionStore
+{
+    private const STATE_TTL = 600;
+
+    public function startLogin(string $state, int $providerId, string $callbackUrl): void
+    {
+        $this->saveContext($state, [
+            'state' => $state,
+            'flow' => 'login',
+            'user_id' => 0,
+            'provider_id' => $providerId,
+            'callback_url' => $callbackUrl,
+            'expires_at' => time() + self::STATE_TTL,
+        ]);
+    }
+
+    public function startBind(string $state, int $providerId, int $userId, string $callbackUrl): void
+    {
+        $this->saveContext($state, [
+            'state' => $state,
+            'flow' => 'bind',
+            'user_id' => $userId,
+            'provider_id' => $providerId,
+            'callback_url' => $callbackUrl,
+            'expires_at' => time() + self::STATE_TTL,
+        ]);
+    }
+
+    public function consumeFlow(string $state, int $providerId, string $callbackUrl): array
+    {
+        $contexts = session('oauth_state_contexts') ?: [];
+        if (!is_array($contexts)) {
+            $contexts = [];
+        }
+        $context = $contexts[$state] ?? null;
+        if (!is_array($context)
+            || empty($context['state'])
+            || !hash_equals((string)$context['state'], $state)
+            || (int)($context['provider_id'] ?? 0) !== $providerId
+            || (string)($context['callback_url'] ?? '') !== $callbackUrl
+            || (int)($context['expires_at'] ?? 0) < time()
+        ) {
+            throw new Exception('授权状态已失效或已处理，请重新发起第三方登录');
+        }
+        unset($contexts[$state]);
+        session('oauth_state_contexts', $contexts);
+        session('oauth_state_context', null);
+        return [(string)(($context['flow'] ?? '') ?: 'login'), (int)($context['user_id'] ?? 0)];
+    }
+
+    private function saveContext(string $state, array $context): void
+    {
+        $contexts = session('oauth_state_contexts') ?: [];
+        if (!is_array($contexts)) {
+            $contexts = [];
+        }
+        $now = time();
+        foreach ($contexts as $key => $storedContext) {
+            if (!is_array($storedContext) || (int)($storedContext['expires_at'] ?? 0) < $now) {
+                unset($contexts[$key]);
+            }
+        }
+        $contexts[$state] = $context;
+        session('oauth_state_contexts', $contexts);
+        session('oauth_state_context', null);
+    }
+}

--- a/app/service/oauth/OAuthTokenStore.php
+++ b/app/service/oauth/OAuthTokenStore.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace app\service\oauth;
+
+use app\lib\oauth\OAuthTokenData;
+
+class OAuthTokenStore
+{
+    public function buildSaveData(OAuthTokenData $tokenData): array
+    {
+        $data = [
+            'refresh_token' => null,
+            'token_expires' => null,
+        ];
+        if ($tokenData->accessToken !== '') {
+            $data['access_token'] = authcode($tokenData->accessToken, 'ENCODE', config_get('sys_key'));
+        }
+        if (!empty($tokenData->refreshToken)) {
+            $data['refresh_token'] = authcode($tokenData->refreshToken, 'ENCODE', config_get('sys_key'));
+        }
+        if (!empty($tokenData->expiresIn)) {
+            $data['token_expires'] = date('Y-m-d H:i:s', time() + $tokenData->expiresIn);
+        }
+        return $data;
+    }
+}

--- a/app/sql/install.sql
+++ b/app/sql/install.sql
@@ -5,7 +5,7 @@ CREATE TABLE `dnsmgr_config` (
   PRIMARY KEY (`key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-INSERT INTO `dnsmgr_config` VALUES ('version', '1049');
+INSERT INTO `dnsmgr_config` VALUES ('version', '1050');
 INSERT INTO `dnsmgr_config` VALUES ('notice_mail', '0');
 INSERT INTO `dnsmgr_config` VALUES ('notice_wxtpl', '0');
 INSERT INTO `dnsmgr_config` VALUES ('mail_smtp', 'smtp.qq.com');
@@ -254,6 +254,50 @@ CREATE TABLE `dnsmgr_sctask` (
   PRIMARY KEY (`id`),
   KEY `did` (`did`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+DROP TABLE IF EXISTS `dnsmgr_oauth_provider`;
+CREATE TABLE `dnsmgr_oauth_provider` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `name` varchar(64) NOT NULL COMMENT '提供商名称',
+  `type` varchar(32) NOT NULL COMMENT '类型: qq/github/oauth2/oidc/cccyun',
+  `logo` varchar(255) DEFAULT NULL COMMENT 'Logo: FA图标类名或URL',
+  `client_id` varchar(255) NOT NULL,
+  `client_secret` varchar(255) NOT NULL,
+  `oauth_authorize_url` varchar(1024) DEFAULT NULL COMMENT '自定义OAuth2授权端点',
+  `oauth_token_url` varchar(1024) DEFAULT NULL COMMENT '自定义OAuth2 Token端点',
+  `oauth_userinfo_url` varchar(1024) DEFAULT NULL COMMENT '自定义OAuth2用户信息端点',
+  `oidc_issuer` varchar(1024) DEFAULT NULL COMMENT 'OIDC发行者URL',
+  `scopes` varchar(1024) DEFAULT NULL COMMENT '请求的scope',
+  `userinfo_fields` text DEFAULT NULL COMMENT '用户信息字段映射JSON',
+  `ext_config` text DEFAULT NULL COMMENT '扩展配置JSON',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1',
+  `sort` int(11) NOT NULL DEFAULT '0',
+  `addtime` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_enabled_sort` (`enabled`, `sort`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+DROP TABLE IF EXISTS `dnsmgr_user_oauth`;
+CREATE TABLE `dnsmgr_user_oauth` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `user_id` int(11) unsigned NOT NULL,
+  `provider_id` int(11) unsigned NOT NULL,
+  `openid` varchar(190) NOT NULL COMMENT 'OAuth用户唯一标识',
+  `nickname` varchar(128) DEFAULT NULL,
+  `email` varchar(128) DEFAULT NULL,
+  `avatar` varchar(255) DEFAULT NULL,
+  `access_token` text DEFAULT NULL COMMENT '加密存储',
+  `refresh_token` text DEFAULT NULL COMMENT '加密存储',
+  `token_expires` datetime DEFAULT NULL,
+  `addtime` datetime DEFAULT NULL,
+  `lasttime` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_provider_openid` (`provider_id`, `openid`),
+  UNIQUE KEY `uk_user_provider` (`user_id`, `provider_id`),
+  KEY `idx_user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT IGNORE INTO `dnsmgr_config` (`key`, `value`) VALUES ('oauth_disable_password', '0');
 
 DROP TABLE IF EXISTS `dnsmgr_domain_alias`;
 CREATE TABLE `dnsmgr_domain_alias` (

--- a/app/sql/update.sql
+++ b/app/sql/update.sql
@@ -213,3 +213,46 @@ CREATE TABLE IF NOT EXISTS `dnsmgr_domain_category` (
 ALTER TABLE `dnsmgr_domain`
 ADD COLUMN `cid` int(11) unsigned NOT NULL DEFAULT '0',
 ADD KEY `cid` (`cid`);
+
+CREATE TABLE IF NOT EXISTS `dnsmgr_oauth_provider` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `name` varchar(64) NOT NULL COMMENT '提供商名称',
+  `type` varchar(32) NOT NULL COMMENT '类型: qq/github/oauth2/oidc/cccyun',
+  `logo` varchar(255) DEFAULT NULL COMMENT 'Logo: FA图标类名或URL',
+  `client_id` varchar(255) NOT NULL,
+  `client_secret` varchar(255) NOT NULL,
+  `oauth_authorize_url` varchar(1024) DEFAULT NULL COMMENT '自定义OAuth2授权端点',
+  `oauth_token_url` varchar(1024) DEFAULT NULL COMMENT '自定义OAuth2 Token端点',
+  `oauth_userinfo_url` varchar(1024) DEFAULT NULL COMMENT '自定义OAuth2用户信息端点',
+  `oidc_issuer` varchar(1024) DEFAULT NULL COMMENT 'OIDC发行者URL',
+  `scopes` varchar(1024) DEFAULT NULL COMMENT '请求的scope',
+  `userinfo_fields` text DEFAULT NULL COMMENT '用户信息字段映射JSON',
+  `ext_config` text DEFAULT NULL COMMENT '扩展配置JSON',
+  `enabled` tinyint(1) NOT NULL DEFAULT '1',
+  `sort` int(11) NOT NULL DEFAULT '0',
+  `addtime` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_enabled_sort` (`enabled`, `sort`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `dnsmgr_user_oauth` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `user_id` int(11) unsigned NOT NULL,
+  `provider_id` int(11) unsigned NOT NULL,
+  `openid` varchar(190) NOT NULL COMMENT 'OAuth用户唯一标识',
+  `nickname` varchar(128) DEFAULT NULL,
+  `email` varchar(128) DEFAULT NULL,
+  `avatar` varchar(255) DEFAULT NULL,
+  `access_token` text DEFAULT NULL COMMENT '加密存储',
+  `refresh_token` text DEFAULT NULL COMMENT '加密存储',
+  `token_expires` datetime DEFAULT NULL,
+  `addtime` datetime DEFAULT NULL,
+  `lasttime` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_provider_openid` (`provider_id`, `openid`),
+  UNIQUE KEY `uk_user_provider` (`user_id`, `provider_id`),
+  KEY `idx_user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+INSERT IGNORE INTO `dnsmgr_config` (`key`, `value`) VALUES ('oauth_disable_password', '0');

--- a/app/utils/CheckUtils.php
+++ b/app/utils/CheckUtils.php
@@ -48,25 +48,8 @@ class CheckUtils
         }
         // 处理代理
         if ($proxy) {
-            $proxy_server = config_get('proxy_server');
-            $proxy_port = intval(config_get('proxy_port'));
-            $proxy_userpwd = config_get('proxy_user').':'.config_get('proxy_pwd');
-            $proxy_type = config_get('proxy_type');
-
-            if (!empty($proxy_server) && !empty($proxy_port)) {
-                match ($proxy_type) {
-                    'https' => $proxy_string = 'https://',
-                    'sock4' => $proxy_string = 'socks4://',
-                    'sock5' => $proxy_string = 'socks5://',
-                    'sock5h' => $proxy_string = 'socks5h://',
-                    default => $proxy_string = 'http://',
-                };
-
-                if ($proxy_userpwd != ':') {
-                    $proxy_string .= $proxy_userpwd . '@';
-                }
-
-                $proxy_string .= $proxy_server . ':' . $proxy_port;
+            $proxy_string = build_guzzle_proxy_url();
+            if ($proxy_string !== null) {
                 $options['proxy'] = $proxy_string;
             }
         }

--- a/app/view/auth/login.html
+++ b/app/view/auth/login.html
@@ -9,7 +9,7 @@
   <link href="/static/css/bootstrap-3.4.1.min.css" rel="stylesheet"/>
   <link href="/static/css/font-awesome-4.7.0.min.css" rel="stylesheet"/>
   <link href="/static/css/app.min.css" rel="stylesheet">
-  <link href="/static/css/skins/{$skin}.css" rel="stylesheet">
+  <link href="/static/css/skins/{:htmlspecialchars($skin ?? '')}.css" rel="stylesheet">
   <link href="/static/css/bootstrap-table.css" rel="stylesheet"/>
   <script src="/static/js/jquery-3.7.1.min.js"></script>
   <!--[if lt IE 9]>
@@ -21,18 +21,26 @@ body{color:#999;background-color:#f1f4fd;background-size:cover}
 a{color:#444}
 .login-screen{max-width:430px;padding:0;margin:100px auto 0 auto}
 .login-screen .well{border-radius:3px;-webkit-box-shadow:0 0 30px rgba(0,0,0,.1);box-shadow:0 0 30px rgba(0,0,0,.1);background:#fff;border:none;padding:0}
-@media (max-width:767px){.login-screen{padding:20px 0}
-}
+@media (max-width:767px){.login-screen{padding:20px 0}}
 .profile-img-card{width:100px;height:100px;display:block;-moz-border-radius:50%;-webkit-border-radius:50%;border-radius:50%;margin:-93px auto 30px;border:5px solid #fff}
 .profile-name-card{text-align:center}
 .login-head{background:#899fe1;border-radius:3px 3px 0 0}
-.login-form{padding:40px 30px;position:relative;z-index:99}
+.login-form{padding:40px 30px 20px 30px;position:relative;z-index:99}
 #login-form{margin-top:20px}
 #login-form .input-group{margin-bottom:15px}
 #login-form .form-control{font-size:14px}
 #totp-form{margin-top:20px}
 #totp-form .input-group{margin-bottom:15px}
 #totp-form .form-control{font-size:14px}
+.oauth-section{padding:12px 30px}
+.oauth-section.has-label{border-top:none}
+.oauth-section.oauth-only{border-top:none;padding-top:0}
+.oauth-btn{display:block;text-align:center;margin-bottom:8px;padding:8px;border-radius:3px;border:1px solid #ddd;color:#555;text-decoration:none;transition:background 0.2s}
+.oauth-btn:hover{text-decoration:none;color:#333;background:#f5f5f5;border-color:#ccc}
+.oauth-btn img,.oauth-btn i.fa{width:20px;text-align:center;margin-right:6px}
+.oauth-label{text-align:center;color:#999;font-size:12px;margin-bottom:8px}
+.login-help{text-align:center;padding:0 30px 15px 30px}
+.login-help a{color:#999;font-size:12px}
 </style>
 </head>
 <body>
@@ -43,10 +51,10 @@ a{color:#444}
                 <div class="login-head">
                     <img src="/static/images/login-head.png" style="width:100%;"/>
                 </div>
-                <div class="login-form">
+                <div class="login-form" {if $oauth_disable_password == '1' && !empty($oauth_providers)}style="padding:15px 30px 0 30px;" {/if}>
                     <img id="profile-img" class="profile-img-card" src="/static/images/user.png"/>
-                    <p id="profile-name" class="profile-name-card"></p> 
-                    <form action="" id="login-form" onsubmit="return doLogin()">
+                    <p id="profile-name" class="profile-name-card"></p>
+                    <form action="" id="login-form" onsubmit="return doLogin()" {if $show_totp || ($oauth_disable_password == '1' && !empty($oauth_providers))}style="display:none;"{/if}>
                         <div class="input-group">
                             <div class="input-group-addon"><span class="glyphicon glyphicon-user" aria-hidden="true"></span></div>
                             <input type="text" class="form-control" placeholder="用户名" name="username" required="required"/>
@@ -65,9 +73,8 @@ a{color:#444}
                         <div class="form-group">
                             <button type="submit" class="btn btn-success btn-lg btn-block" id="submit" style="background:#708eea;">登 录</button>
                         </div>
-                        <div class="pull-right"><a href="javascript:findpwd()">忘记密码</a></div>
                     </form>
-                    <form action="" id="totp-form" onsubmit="return doTotp()" style="display:none;">
+                    <form action="" id="totp-form" onsubmit="return doTotp()" {if !$show_totp}style="display:none;"{/if}>
                         <div class="alert alert-info" role="alert">TOTP二次验证</div>
                         <div class="input-group">
                             <div class="input-group-addon"><span class="glyphicon glyphicon-lock" aria-hidden="true"></span></div>
@@ -76,30 +83,50 @@ a{color:#444}
                         <div class="form-group">
                             <button type="submit" class="btn btn-success btn-lg btn-block" id="submit" style="background:#708eea;">登 录</button>
                         </div>
-                        <div class="pull-right"><a href="javascript:findpwd()">忘记密码</a></div>
                     </form>
+                </div>
+                {if !empty($oauth_providers)}
+                <div class="oauth-section {if $oauth_disable_password != '1'}has-label{else}oauth-only{/if}">
+                    {if $oauth_disable_password != '1'}<div class="oauth-label">— 或使用第三方账号登录 —</div>{/if}
+                    {foreach $oauth_providers as $p}
+                    <a href="/oauth/login/{$p.id}" class="oauth-btn">
+                        {php}
+                        $logo = (string)($p['logo'] ?? '');
+                        if (preg_match('/^https?:\/\//i', $logo)) echo '<img src="'.htmlspecialchars($logo).'" alt="">';
+                        elseif (preg_match('/^fa-[a-z0-9-]+$/i', $logo)) echo '<i class="fa '.htmlspecialchars($logo).' fa-fw"></i>';
+                        echo htmlspecialchars($p['name'] ?? '').' 登录';
+                        {/php}
+                    </a>
+                    {/foreach}
+                </div>
+                {/if}
+                <div class="login-help">
+                    <a href="javascript:showHelp()">无法登录？</a>
                 </div>
             </div>
         </div>
     </div>
 </div>
-<div class="modal" id="modal-findpwd">
-	<div class="modal-dialog" role="document">
-		<div class="modal-content">
-			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
-					<span aria-hidden="true">&times;</span>
-				</button>
-				<h4 class="modal-title">忘记密码</h4>
-			</div>
-			<div class="modal-body">
-				<strong>重置密码</strong>
-                <p>进入网站根目录，执行命令：<br/><code>php think reset pwd 用户名 密码</code></p>
-                <strong>关闭TOTP</strong>
-                <p>进入网站根目录，执行命令：<br/><code>php think reset totp 用户名</code></p>
-			</div>
-		</div>
-	</div>
+<div class="modal" id="modal-help">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h4 class="modal-title">无法登录</h4>
+            </div>
+            <div class="modal-body">
+                <p><strong>进入网站根目录，执行相应命令：</strong></p>
+                <p>重置密码<br/>
+                <code>php think reset pwd 用户名 密码</code></p>
+                <p>关闭TOTP<br/>
+                <code>php think reset totp 用户名</code></p>
+                <p>启用密码登录<br/>
+                <code>php think reset oauth_disable_password</code></p>
+            </div>
+        </div>
+    </div>
 </div>
 <script src="/static/js/bootstrap-3.4.1.min.js"></script>
 <script src="/static/js/layer/layer.js"></script>
@@ -142,6 +169,10 @@ function doLogin(){
                 }
                 layer.alert(data.msg, {icon: 2});
             }
+        },
+        error: function(){
+            layer.close(ii);
+            layer.alert('请求失败，请检查网络连接并确认登录服务可用后重试', {icon: 2});
         }
     });
     return false;
@@ -149,31 +180,42 @@ function doLogin(){
 function doTotp(){
     var code = $("#totp_code").val();
     if(code.length != 6){
-		layer.msg('动态口令格式错误', {icon: 2});
-		return false;
-	}
-	var ii = layer.load(2, {shade:[0.1,'#fff']});
-	$.post('/auth/totp', {code:code}, function(res){
-		layer.close(ii);
-		if(res.code == 0){
-			layer.msg('登录成功，正在跳转到首页', {icon: 1,shade: 0.01,time: 15000});
+        layer.msg('动态口令格式错误', {icon: 2});
+        return false;
+    }
+    var ii = layer.load(2, {shade:[0.1,'#fff']});
+    $.post('/auth/totp', {code:code}, function(res){
+        layer.close(ii);
+        if(res.code == 0){
+            layer.msg('登录成功，正在跳转到首页', {icon: 1,shade: 0.01,time: 15000});
             window.location.href = '/';
-		}else{
-			layer.alert(res.msg, {icon: 2});
-		}
-	});
-	return false;
+        }else{
+            layer.alert(res.msg, {icon: 2}, function(index){
+                layer.close(index);
+                if(res.msg && (res.msg.indexOf('请重新登录') !== -1 || res.msg.indexOf('错误次数过多') !== -1)){
+                    $('#totp_code').val('');
+                    $('#totp-form').hide();
+                    $('#login-form').show();
+                    $('#verifycode').attr('src', '/verifycode?r='+Math.random());
+                }
+            });
+        }
+    }).fail(function(){
+        layer.close(ii);
+        layer.alert('请求失败，请重试', {icon: 2});
+    });
+    return false;
 }
-function findpwd(){
-    $('#modal-findpwd').modal('show');
+function showHelp(){
+    $('#modal-help').modal('show');
 }
 $(document).ready(function(){
-	$("#totp_code").keyup(function(){
-		var code = $(this).val();
-		if(code.length == 6){
-			$("#totp-form").submit();
-		}
-	});
+    $("#totp_code").keyup(function(){
+        var code = $(this).val();
+        if(code.length == 6){
+            $("#totp-form").submit();
+        }
+    });
 });
 </script>
 </body>

--- a/app/view/common/layout.html
+++ b/app/view/common/layout.html
@@ -10,7 +10,7 @@
   <link href="/static/css/font-awesome-4.7.0.min.css" rel="stylesheet"/>
   <link href="/static/css/select2-4.0.13.min.css" rel="stylesheet"/>
   <link href="/static/css/app.min.css" rel="stylesheet">
-  <link href="/static/css/skins/{$skin}.css" rel="stylesheet">
+  <link href="/static/css/skins/{:htmlspecialchars($skin ?? '')}.css" rel="stylesheet">
   <link href="/static/css/bootstrap-table.css?v=2" rel="stylesheet"/>
   {if file_exists(public_path() . 'static/css/custom.css')}
   <link href="/static/css/custom.css" rel="stylesheet">
@@ -25,7 +25,7 @@
   </style>
 </head>
 
-<body class="hold-transition {$skin} sidebar-mini">
+<body class="hold-transition {:htmlspecialchars($skin ?? '')} sidebar-mini">
   <div class="wrapper">
     <header class="main-header">
       <!-- Logo -->
@@ -60,21 +60,21 @@
             <li class="dropdown user user-menu">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                 <img src="/static/images/user.png" class="user-image" alt="User Image">
-                <span class="hidden-xs">{$user.username}</span>
+                <span class="hidden-xs">{:htmlspecialchars($user['username'] ?? '')}</span>
               </a>
               <ul class="dropdown-menu">
                 <!-- User image -->
                 <li class="user-header">
                   <img src="/static/images/user.png" class="img-circle" alt="User Image">
                   <p>
-                    {$user.username}
-                    <small>{$user.regtime}</small>
+                    {:htmlspecialchars($user['username'] ?? '')}
+                    <small>{:htmlspecialchars($user['regtime'] ?? '')}</small>
                   </p>
                 </li>
                 <!-- Menu Footer-->
                 <li class="user-footer">
                   {if request()->user['type'] eq 'user'}<div class="pull-left">
-                    <a href="/setpwd" class="btn btn-primary"><i class="fa fa-lock"></i> 修改密码</a>
+                    <a href="/user/center" class="btn btn-primary"><i class="fa fa-user-circle"></i> 用户中心</a>
                   </div>{/if}
                   <div class="pull-right">
                     <a href="/logout" class="btn btn-danger"><i class="fa fa-sign-out"></i> 退出登录</a>
@@ -96,7 +96,7 @@
             <img src="/static/images/user.png" class="img-circle" alt="User Image">
           </div>
           <div class="pull-left info">
-            <p>{$user.username}</p>
+            <p>{:htmlspecialchars($user['username'] ?? '')}</p>
             <i class="fa fa-circle text-success"></i> Online
           </div>
         </div>

--- a/app/view/dispatch_jump.html
+++ b/app/view/dispatch_jump.html
@@ -27,34 +27,36 @@
     </style>
 </head>
 <body>
-<div class="system-message {$code}">
+<div class="system-message {$code|htmlentities}">
     <div class="image">
-        <img src="/static/images/{$code}.svg" alt="" width="150" />
+        <img src="/static/images/{$code|htmlentities}.svg" alt="" width="150" />
     </div>
-    <h1>{$msg}</h1>
+    <h1>{$msg|htmlentities}</h1>
     {if $url}
         <p class="jump">
-            页面将在 <span id="wait">{$wait}</span> 秒后自动跳转
+            页面将在 <span id="wait">{$wait|htmlentities}</span> 秒后自动跳转
         </p>
     {/if}
     <p class="clearfix">
         <a href="javascript:history.go(-1);" class="btn btn-grey">返回上一页</a>
         {if $url}
-            <a href="{$url}" class="btn btn-primary">立即跳转</a>
+            <a href="{$url|htmlentities}" class="btn btn-primary">立即跳转</a>
         {/if}
     </p>
 </div>
-    <script type="text/javascript">
-        (function () {
-            var wait = document.getElementById('wait');
-            var interval = setInterval(function () {
-                var time = --wait.innerHTML;
-                if (time <= 0) {
-                    location.href = "{$url}";
-                    clearInterval(interval);
-                }
-            }, 1000);
-        })();
-    </script>
+    {if $url}
+        <script type="text/javascript">
+            (function () {
+                var wait = document.getElementById('wait');
+                var interval = setInterval(function () {
+                    var time = --wait.innerHTML;
+                    if (time <= 0) {
+                        location.href = {$url|json_encode|raw};
+                        clearInterval(interval);
+                    }
+                }, 1000);
+            })();
+        </script>
+    {/if}
 </body>
 </html>

--- a/app/view/index/user_center.html
+++ b/app/view/index/user_center.html
@@ -1,0 +1,265 @@
+{extend name="common/layout" /}
+{block name="title"}用户中心{/block}
+{block name="main"}
+<div class="row">
+<div class="col-md-6">
+    <div class="panel panel-primary">
+        <div class="panel-heading"><h3 class="panel-title">个人信息</h3></div>
+        <div class="panel-body">
+            <table class="table table-striped">
+                <tr><td width="100">用户名</td><td>{:htmlspecialchars($user['username'] ?? '')}</td></tr>
+                <tr><td>用户等级</td><td>
+                    {if $user.level == 2}<span class="label label-danger">超级管理员</span>
+                    {elseif $user.level == 1}<span class="label label-warning">管理员</span>
+                    {else}<span class="label label-info">普通用户</span>
+                    {/if}
+                </td></tr>
+                <tr><td>注册时间</td><td>{:htmlspecialchars($user['regtime'] ?? '')}</td></tr>
+                <tr><td>上次登录</td><td>{:htmlspecialchars($user['lasttime'] ?? '')}</td></tr>
+            </table>
+        </div>
+    </div>
+
+    <div class="panel panel-info">
+        <div class="panel-heading"><h3 class="panel-title">第三方账号绑定</h3></div>
+        <div class="panel-body">
+            {if empty($providers)}
+            <p class="text-muted">暂无可用的第三方登录方式</p>
+            {else}
+            <div class="list-group" style="margin-bottom:0;">
+                {foreach $providers as $p}
+                <div class="list-group-item">
+                    <div class="row" style="display:flex;align-items:center;">
+                        <div class="col-xs-5">
+                            {php}
+                            $logo = (string)($p['logo'] ?? '');
+                            if (preg_match('/^https?:\/\//i', $logo)) echo '<img src="'.htmlspecialchars($logo).'" style="height:20px;margin-right:8px;" alt="">';
+                            elseif (preg_match('/^fa-[a-z0-9-]+$/i', $logo)) echo '<i class="fa '.htmlspecialchars($logo).' fa-fw"></i>';
+                            echo '<strong>'.htmlspecialchars($p['name'] ?? '').'</strong>';
+                            {/php}
+                        </div>
+                        <div class="col-xs-4">
+                            {if isset($p.bind_display_name)}
+                            {php}
+                            $avatar = (string)($p['bind_avatar'] ?? '');
+                            if (preg_match('/^https?:\/\//i', $avatar)) echo '<img src="'.htmlspecialchars($avatar).'" style="width:24px;height:24px;border-radius:50%;margin-right:6px;vertical-align:middle;" alt="">';
+                            echo '<span title="'.htmlspecialchars($p['bind_display_name']).'">'.htmlspecialchars($p['bind_display_name']).'</span>';
+                            {/php}
+                            {else}
+                            <span class="text-muted">未绑定</span>
+                            {/if}
+                        </div>
+                        <div class="col-xs-3 text-right">
+                            {if isset($p.bind_display_name)}
+                            <button type="button" class="btn btn-success btn-xs" disabled>已绑定</button>
+                            <button type="button" class="btn btn-danger btn-xs" onclick="unbindOauth({$p.id})">解绑</button>
+                            {else}
+                            <button type="button" class="btn btn-primary btn-xs" onclick="bindOauth({$p.id})">绑定</button>
+                            {/if}
+                        </div>
+                    </div>
+                </div>
+                {/foreach}
+            </div>
+            {/if}
+        </div>
+        <div class="panel-footer">
+            <span class="glyphicon glyphicon-info-sign"></span> 绑定第三方账号后，可使用第三方账号直接登录，无需输入密码。
+        </div>
+    </div>
+</div>
+
+<div class="col-md-6">
+    <div class="panel panel-default">
+        <div class="panel-heading"><h3 class="panel-title">修改密码</h3></div>
+        <div class="panel-body">
+            <form onsubmit="return changePwd()">
+                <div class="form-group">
+                    <label>旧密码</label>
+                    <input type="password" name="oldpwd" class="form-control" placeholder="请输入当前密码" required>
+                </div>
+                <div class="form-group">
+                    <label>新密码</label>
+                    <input type="password" name="newpwd" class="form-control" placeholder="请输入新密码" required>
+                </div>
+                <div class="form-group">
+                    <label>确认新密码</label>
+                    <input type="password" name="newpwd2" class="form-control" placeholder="请再次输入新密码" required>
+                </div>
+                <button type="submit" class="btn btn-success btn-block">修改密码</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="panel panel-warning">
+        <div class="panel-heading"><h3 class="panel-title">TOTP 二次验证</h3></div>
+        <div class="panel-body">
+            <div class="input-group">
+                {if $user.totp_open == 1}
+                <input type="text" class="form-control" value="已开启" style="color:green;" readonly>
+                <div class="input-group-btn"><button type="button" class="btn btn-info" onclick="openTotp()">重置</button></div>
+                <div class="input-group-btn"><button type="button" class="btn btn-danger" onclick="closeTotp()">关闭</button></div>
+                {else}
+                <input type="text" class="form-control" value="未开启" style="color:blue;" readonly>
+                <div class="input-group-btn"><button type="button" class="btn btn-info" onclick="openTotp()">开启</button></div>
+                {/if}
+            </div>
+        </div>
+        <div class="panel-footer">
+            <span class="glyphicon glyphicon-info-sign"></span> 开启后登录需使用支持 TOTP 的认证软件进行二次验证，提高账号安全性。
+        </div>
+    </div>
+</div>
+</div>
+
+<!-- TOTP 绑定弹窗 -->
+<div class="modal" id="modal-totp" data-backdrop="static" data-keyboard="false">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">TOTP 绑定</h4>
+            </div>
+            <div class="modal-body text-center">
+                <p>使用支持 TOTP 的认证软件扫描以下二维码</p>
+                <div class="mt-4" id="qrcode"></div>
+                <p class="mt-2"><a href="javascript:;" id="copy-btn" data-clipboard-text="">复制密钥</a></p>
+                <form id="form-totp" style="text-align:left;" onsubmit="return bindTotp()">
+                    <div class="form-group mt-4">
+                        <div class="input-group">
+                            <input type="number" class="form-control input-lg" name="code" id="totp_code" placeholder="填写动态口令" autocomplete="off" required>
+                            <div class="input-group-btn"><button type="submit" class="btn btn-success btn-lg">完成绑定</button></div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{/block}
+{block name="script"}
+<script src="/static/js/layer/layer.js"></script>
+<script src="/static/js/jquery-qrcode-1.0.min.js"></script>
+<script src="/static/js/clipboard-1.7.1.min.js"></script>
+<script>
+var totpData = {secret:null, qrcode:null};
+
+// ----- 修改密码 -----
+function changePwd(){
+    var oldpwd = $('input[name="oldpwd"]').val();
+    var newpwd = $('input[name="newpwd"]').val();
+    var newpwd2 = $('input[name="newpwd2"]').val();
+    if(!oldpwd || !newpwd || !newpwd2){ layer.msg('请填写完整', {icon:2}); return false; }
+    if(newpwd != newpwd2){ layer.msg('两次输入的密码不一致', {icon:2}); return false; }
+    var ii = layer.load(2, {shade:[0.1,'#fff']});
+    $.post('/setpwd', {oldpwd:oldpwd, newpwd:newpwd, newpwd2:newpwd2}, function(res){
+        layer.close(ii);
+        if(res.code == 0){
+            layer.alert('密码修改成功，请重新登录。', {icon:1, closeBtn:false}, function(){
+                window.location.href = '/logout';
+            });
+        }else{
+            layer.alert(res.msg, {icon:2});
+        }
+    });
+    return false;
+}
+
+// ----- OAuth 绑定 -----
+function bindOauth(providerId){
+    var form = $('<form>', {method: 'post', action: '/oauth/bind/' + providerId});
+    $('body').append(form);
+    form.submit();
+}
+
+// ----- OAuth 解绑 -----
+function unbindOauth(providerId){
+    layer.confirm('确定要解绑该第三方账号吗？<br/>解绑后将无法使用该账号登录。', {
+        btn: ['确定解绑','取消'], btnAlign: 'c',
+    }, function(){
+        var ii = layer.load(2, {shade:[0.1,'#fff']});
+        $.post('/oauth/unbind', {provider_id: providerId}, function(res){
+            layer.close(ii);
+            if(res.code == 0){
+                layer.msg('解绑成功', {icon:1, time:1000}, function(){ window.location.reload(); });
+            }else{
+                layer.alert(res.msg, {icon:2});
+            }
+        }).fail(function(){
+            layer.close(ii);
+            layer.alert('解绑请求失败，请检查网络后重试', {icon:2});
+        });
+    });
+}
+
+// ----- TOTP -----
+function openTotp(){
+    if(!totpData.qrcode || !totpData.secret){
+        var ii = layer.load(2, {shade:[0.1,'#fff']});
+        $.post('/totp/generate', {}, function(res){
+            layer.close(ii);
+            if(res.code == 0){
+                totpData.secret = res.data.secret;
+                totpData.qrcode = res.data.qrcode;
+                $('#qrcode').qrcode({text: totpData.qrcode, width: 150, height: 150, foreground: "#000", background: "#fff", typeNumber: -1});
+                $('#copy-btn').attr('data-clipboard-text', totpData.secret);
+                $('#modal-totp').modal('show');
+                $('#totp_code').focus();
+            }else{
+                layer.alert(res.msg, {icon:2});
+            }
+        }).fail(function(){
+            layer.close(ii);
+            layer.alert('请求失败，请重试', {icon:2});
+        });
+    }else{
+        $('#modal-totp').modal('show');
+        $('#totp_code').focus();
+    }
+}
+function bindTotp(){
+    var code = $('#totp_code').val();
+    if(code.length != 6){ layer.msg('动态口令格式错误', {icon:2}); return false; }
+    $('#totp_code, #form-totp button[type="submit"]').prop('disabled', true);
+    var ii = layer.load(2, {shade:[0.1,'#fff']});
+    $.post('/totp/bind', {secret:totpData.secret, code:code}, function(res){
+        layer.close(ii);
+        $('#totp_code, #form-totp button[type="submit"]').prop('disabled', false);
+        if(res.code == 0){
+            layer.alert('TOTP 绑定成功', {icon:1}, function(){ window.location.reload(); });
+        }else{
+            layer.alert(res.msg, {icon:2});
+        }
+    }).fail(function(){
+        layer.close(ii);
+        $('#totp_code, #form-totp button[type="submit"]').prop('disabled', false);
+        layer.alert('请求失败，请重试', {icon:2});
+    });
+    return false;
+}
+function closeTotp(){
+    layer.confirm('确定要关闭 TOTP 二次验证吗？', {btn: ['确定','取消']}, function(){
+        var ii = layer.load(2, {shade:[0.1,'#fff']});
+        $.post('/totp/close', {}, function(res){
+            layer.close(ii);
+            if(res.code == 0){
+                layer.alert('TOTP 已关闭', {icon:1}, function(){ window.location.reload(); });
+            }else{
+                layer.alert(res.msg, {icon:2});
+            }
+        }).fail(function(){
+            layer.close(ii);
+            layer.alert('请求失败，请重试', {icon:2});
+        });
+    });
+}
+$(document).ready(function(){
+    var clipboard = new Clipboard('#copy-btn');
+    clipboard.on('success', function(){ layer.msg('复制成功', {icon:1, time:600}); });
+    clipboard.on('error', function(){ layer.msg('复制失败', {icon:2}); });
+    $('#totp_code').keyup(function(){
+        if($(this).val().length == 6) $('#form-totp').submit();
+    });
+});
+</script>
+{/block}

--- a/app/view/system/loginset.html
+++ b/app/view/system/loginset.html
@@ -7,23 +7,198 @@
 <div class="panel-heading"><h3 class="panel-title">登录验证码设置</h3></div>
 <div class="panel-body">
     <div class="form-group">
-        <div class="form-group">
-            <label class="col-sm-3 control-label">开启图形验证码</label>
-            <div class="col-sm-9"><div class="material-switch"><input id="vocde_switch" type="checkbox" {if config_get('vcode', '1')=='1'}checked{/if} onchange="setvcode()"><label for="vocde_switch" class="label-primary"></label></div></div>
+        <label class="col-sm-3 control-label">开启图形验证码</label>
+        <div class="col-sm-9"><div class="material-switch"><input id="vocde_switch" type="checkbox" {if config_get('vcode', '1')=='1'}checked{/if} onchange="setvcode()"><label for="vocde_switch" class="label-primary"></label></div></div>
+    </div>
+</div>
+</div>
+</div>
+
+<div class="col-xs-12 col-sm-8 col-lg-6 center-block" style="float: none;">
+<div class="panel panel-danger">
+<div class="panel-heading"><h3 class="panel-title">第三方登录设置</h3></div>
+<div class="panel-body">
+    <div class="form-group">
+        <label class="col-sm-3 control-label">禁用密码登录</label>
+        <div class="col-sm-9">
+            <div class="material-switch"><input id="oauth_disable_password_switch" type="checkbox" {if config_get('oauth_disable_password', '0')=='1'}checked{/if} onchange="setOauthDisablePassword()"><label for="oauth_disable_password_switch" class="label-danger"></label></div>
+            <p class="help-block text-danger">
+                <strong>警告：</strong>开启后所有用户将无法使用密码登录，仅能通过已绑定的第三方账号登录。<br/>
+                开启前请确保至少有一个管理员账号已绑定第三方登录，否则将无法登录后台！<br/>
+                如需关闭且无法登录，可在网站根目录执行：<code>php think reset oauth_disable_password</code>
+            </p>
         </div>
     </div>
 </div>
 </div>
 </div>
+
+<div class="col-xs-12 col-sm-8 col-lg-6 center-block" style="float: none;">
+<div class="panel panel-default">
+<div class="panel-heading clearfix">
+    <h3 class="panel-title pull-left" style="padding-top:7px;">OAuth 提供商</h3>
+    <button type="button" class="btn btn-primary btn-sm pull-right" onclick="showEdit()"><i class="fa fa-plus"></i> 添加</button>
+</div>
+<div class="panel-body" style="padding:0;">
+    <table class="table table-striped table-hover" style="margin-bottom:0;">
+        <thead>
+            <tr><th style="width:45px;">ID</th><th>名称</th><th style="width:100px;">类型</th><th style="width:55px;">状态</th><th style="width:55px;">排序</th><th style="width:130px;">操作</th></tr>
+        </thead>
+        <tbody id="provider-tbody">
+            <tr id="provider-empty"><td colspan="6" class="text-center text-muted">暂无提供商，点击"添加"按钮创建</td></tr>
+        </tbody>
+    </table>
+</div>
+<div class="panel-footer">
+    <i class="fa fa-info-circle"></i> 回调地址格式：<code>{:htmlspecialchars($siteurl)}/oauth/callback/</code><b> + 提供商ID</b>。在 OAuth 平台填写回调地址时请先添加提供商获取 ID。
+</div>
+</div>
+</div>
+</div>
+
+<div class="modal" id="modal-edit" data-backdrop="static" data-keyboard="false">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="modal-title">添加提供商</h4>
+            </div>
+            <div class="modal-body">
+                <form id="form-edit" onsubmit="return saveProvider()" class="form-horizontal">
+                    <input type="hidden" name="id" value="">
+                    <input type="hidden" name="enabled" value="0">
+                    <div class="form-group">
+                        <label class="col-sm-3 control-label">提供商类型</label>
+                        <div class="col-sm-9">
+                            <select name="type" class="form-control" onchange="onTypeChange()" required>
+                                <option value="">请选择类型</option>
+                                <option value="qq">QQ互联</option>
+                                <option value="github">GitHub</option>
+                                <option value="cccyun">彩虹聚合登录</option>
+                                <option value="oauth2">自定义 OAuth 2.0</option>
+                                <option value="oidc">自定义 OIDC</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-sm-3 control-label">显示名称</label>
+                        <div class="col-sm-9"><input type="text" name="name" class="form-control" placeholder="如：GitHub" required></div>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-sm-3 control-label">Logo图标</label>
+                        <div class="col-sm-9">
+                            <input type="text" name="logo" class="form-control" placeholder="Font Awesome类名或图片URL">
+                            <span class="help-block">如 <code>fa-github</code>、<code>fa-qq</code> 或 <code>https://example.com/logo.png</code></span>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-sm-3 control-label">Client ID</label>
+                        <div class="col-sm-9"><input type="text" name="client_id" class="form-control" placeholder="App ID / Client ID" required></div>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-sm-3 control-label">Client Secret</label>
+                        <div class="col-sm-9">
+                            <input type="password" name="client_secret" class="form-control" placeholder="App Secret / Client Secret" autocomplete="off" required>
+                            <span class="help-block text-muted edit-hint" style="display:none;">编辑时留空则不修改已保存的密钥</span>
+                        </div>
+                    </div>
+                    <div class="form-group scopes-field">
+                        <label class="col-sm-3 control-label">Scopes</label>
+                        <div class="col-sm-9">
+                            <input type="text" name="scopes" class="form-control" placeholder="留空使用默认值">
+                        </div>
+                    </div>
+                    <div class="oauth2-fields" style="display:none;">
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">授权端点 URL</label>
+                            <div class="col-sm-9"><input type="text" name="oauth_authorize_url" class="form-control" placeholder="https://example.com/oauth/authorize"></div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">Token 端点 URL</label>
+                            <div class="col-sm-9"><input type="text" name="oauth_token_url" class="form-control" placeholder="https://example.com/oauth/token"></div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">用户信息端点 URL</label>
+                            <div class="col-sm-9"><input type="text" name="oauth_userinfo_url" class="form-control" placeholder="https://example.com/api/user"></div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">字段映射 (JSON)</label>
+                            <div class="col-sm-9">
+                                <input type="text" name="userinfo_fields" class="form-control" placeholder='{"openid":"id","nickname":"name","email":"email","avatar":"avatar_url"}'>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="oidc-fields" style="display:none;">
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">Issuer URL</label>
+                            <div class="col-sm-9">
+                                <input type="text" name="oidc_issuer" class="form-control" placeholder="https://accounts.google.com">
+                                <span class="help-block">系统将自动通过 <code>/.well-known/openid-configuration</code> 发现端点</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="qq-fields" style="display:none;">
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">获取UnionID</label>
+                            <div class="col-sm-9">
+                                <div class="material-switch"><input id="unionid_switch" type="checkbox" value="1"><label for="unionid_switch" class="label-primary"></label></div>
+                                <span class="help-block">开启后使用 UnionID 作为用户唯一标识（跨应用统一）。需要在 QQ 互联平台申请 UnionID 权限。</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="cccyun-fields" style="display:none;">
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">接口域名</label>
+                            <div class="col-sm-9">
+                                <input type="text" name="cccyun_url" class="form-control" placeholder="https://u.cccyun.cc/">
+                                <span class="help-block">自建彩虹聚合登录填写基础域名即可，系统会自动补齐 <code>/connect.php</code>。留空使用官方接口。</span>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">登录方式</label>
+                            <div class="col-sm-9">
+                                <select name="cccyun_type" class="form-control">
+                                    <option value="qq">QQ</option>
+                                    <option value="wx">微信</option>
+                                    <option value="alipay">支付宝</option>
+                                    <option value="sina">微博</option>
+                                    <option value="baidu">百度</option>
+                                    <option value="huawei">华为</option>
+                                    <option value="xiaomi">小米</option>
+                                    <option value="douyin">抖音</option>
+                                    <option value="bilibili">哔哩哔哩</option>
+                                    <option value="dingtalk">钉钉</option>
+                                </select>
+                                <span class="help-block">对应彩虹聚合登录接口的 type 参数。Client ID 填写 appid，Client Secret 填写 appkey。已有用户绑定后修改登录方式会影响原绑定账号登录。</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-sm-3 control-label">排序</label>
+                        <div class="col-sm-9"><input type="number" name="sort" class="form-control" value="0"></div>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-sm-3 control-label">启用</label>
+                        <div class="col-sm-9">
+                            <div class="material-switch"><input id="enabled_checkbox" type="checkbox" checked onchange="$('input[name=enabled]').val(this.checked?'1':'0')"><label for="enabled_checkbox" class="label-primary"></label></div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">取消</button>
+                <button type="button" class="btn btn-primary" onclick="$('#form-edit').submit()">保存</button>
+            </div>
+        </div>
+    </div>
 </div>
 {/block}
 {block name="script"}
 <script src="/static/js/layer/layer.js"></script>
 <script>
-var items = $("select[default]");
-for (i = 0; i < items.length; i++) {
-	$(items[i]).val($(items[i]).attr("default")||0);
-}
+var oauthEditorMode = 'add';
+var oauthEditorId = 0;
+
 function setvcode(){
     var status = $("#vocde_switch").is(':checked') ? '1' : '2';
     $.post('/system/set', {vcode: status}, function(res){
@@ -31,9 +206,292 @@ function setvcode(){
             layer.msg(status == '1' ? '图形验证码已开启' : '图形验证码已关闭', {icon: 1, time: 1000});
         }else{
             layer.alert(res.msg, {icon: 2});
-            $("#vocde_switch").prop('checked', !status);
+            $("#vocde_switch").prop('checked', status == '2');
         }
     });
 }
+
+function setOauthDisablePassword(){
+    var status = $("#oauth_disable_password_switch").is(':checked') ? '1' : '0';
+    $.post('/system/set', {oauth_disable_password: status}, function(res){
+        if(res.code == 0){
+            layer.msg(status == '1' ? '密码登录已禁用' : '密码登录已启用', {icon: 1, time: 1000});
+        }else{
+            layer.alert(res.msg, {icon: 2});
+            $("#oauth_disable_password_switch").prop('checked', status == '0');
+        }
+    }).fail(function(){
+        layer.alert('请求失败，请重试', {icon: 2});
+        $("#oauth_disable_password_switch").prop('checked', status == '0');
+    });
+}
+
+function escapeHtml(value){
+    return String(value == null ? '' : value).replace(/[&<>"']/g, function(ch){
+        return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch];
+    });
+}
+function safeLogoHtml(logo){
+    logo = String(logo || '');
+    if(/^https?:\/\//i.test(logo)){
+        return '<img src="'+escapeHtml(logo)+'" style="height:18px;margin-right:6px;">';
+    }
+    if(/^fa-[a-z0-9-]+$/i.test(logo)){
+        return '<i class="fa '+escapeHtml(logo)+' fa-fw" style="margin-right:4px;"></i>';
+    }
+    return '';
+}
+
+function loadProviders(){
+    $.post('/system/oauth/data', {offset:0, limit:50, sort:'sort', order:'asc'}, function(res){
+        var tbody = $('#provider-tbody');
+        tbody.empty();
+        if(!res.rows || !Array.isArray(res.rows) || res.rows.length === 0){
+            tbody.html('<tr><td colspan="6" class="text-center text-muted">暂无提供商，点击"添加"按钮创建</td></tr>');
+            return;
+        }
+        var typeMap = {qq:'QQ互联', github:'GitHub', cccyun:'彩虹聚合登录', oauth2:'自定义OAuth2.0', oidc:'自定义OIDC'};
+        for(var i=0; i<res.rows.length; i++){
+            var r = res.rows[i];
+            var logoHtml = safeLogoHtml(r.logo);
+            var statusHtml = r.enabled == 1 ? '<span class="label label-success">启用</span>' : '<span class="label label-default">禁用</span>';
+            var name = escapeHtml(r.name);
+            var type = escapeHtml(typeMap[r.type] || r.type);
+            var sort = escapeHtml(r.sort);
+            var tr = '<tr>'
+                + '<td>'+escapeHtml(r.id)+'</td>'
+                + '<td>' + logoHtml + name + '</td>'
+                + '<td>'+type+'</td>'
+                + '<td>'+statusHtml+'</td>'
+                + '<td>'+sort+'</td>'
+                + '<td>'
+                + '<button type="button" class="btn btn-xs btn-info" data-id="'+escapeHtml(r.id)+'" onclick="openEditProvider($(this).data(\'id\'))"><i class="fa fa-edit"></i> 编辑</button> '
+                + '<button type="button" class="btn btn-xs btn-danger" data-id="'+escapeHtml(r.id)+'" data-name="'+name+'" onclick="deleteProvider($(this).data(\'id\'), $(this).data(\'name\'))"><i class="fa fa-trash"></i> 删除</button>'
+                + '</td></tr>';
+            tbody.append(tr);
+        }
+    }).fail(function(){
+        $('#provider-tbody').html('<tr><td colspan="6" class="text-center text-danger">加载失败，请刷新页面重试</td></tr>');
+    });
+}
+
+function resetProviderForm(){
+    $('#form-edit')[0].reset();
+    $('input[name="id"]').val('');
+    $('input[name="enabled"]').val('1');
+    $('#enabled_checkbox').prop('checked', true);
+    $('#unionid_switch').prop('checked', false);
+    $('input[name="cccyun_url"]').val('');
+    $('select[name="cccyun_type"]').val('qq');
+    $('.oauth2-fields,.oidc-fields,.qq-fields,.cccyun-fields').hide();
+}
+
+function openAddProvider(){
+    oauthEditorMode = 'add';
+    oauthEditorId = 0;
+    resetProviderForm();
+    $('#modal-title').text('添加提供商');
+    $('input[name="client_secret"]').attr('required', true).val('').attr('placeholder', 'App Secret / Client Secret');
+    $('.edit-hint').hide();
+    $('#modal-edit').modal('show');
+}
+
+function showOAuthAdminRequestFailed(){
+    layer.alert('请求失败，请检查网络连接并确认当前后台登录未过期；如仍失败请查看服务器日志', {icon: 2});
+}
+
+function openEditProvider(id){
+    oauthEditorMode = 'edit';
+    oauthEditorId = id;
+    resetProviderForm();
+    $('#modal-title').text('编辑提供商');
+    $('input[name="client_secret"]').removeAttr('required').val('').attr('placeholder', '留空则不修改');
+    $('.edit-hint').show();
+
+    var ii = layer.load(2, {shade:[0.1,'#fff']});
+    $.post('/system/oauth/op', {act:'get', id:id}, function(res){
+        layer.close(ii);
+        if(res.code != 0){
+            layer.alert(res.msg, {icon: 2});
+            return;
+        }
+        var data = res.data;
+        $('input[name="id"]').val(data.id);
+        $('select[name="type"]').val(data.type);
+        $('input[name="name"]').val(data.name || '');
+        $('input[name="logo"]').val(data.logo || '');
+        $('input[name="client_id"]').val(data.client_id || '');
+        $('input[name="scopes"]').val(data.scopes || '');
+        $('input[name="oauth_authorize_url"]').val(data.oauth_authorize_url || '');
+        $('input[name="oauth_token_url"]').val(data.oauth_token_url || '');
+        $('input[name="oauth_userinfo_url"]').val(data.oauth_userinfo_url || '');
+        $('input[name="oidc_issuer"]').val(data.oidc_issuer || '');
+        $('input[name="userinfo_fields"]').val(data.userinfo_fields || '');
+        $('input[name="sort"]').val(data.sort || 0);
+        $('input[name="enabled"]').val(data.enabled == 1 ? '1' : '0');
+        $('#enabled_checkbox').prop('checked', data.enabled == 1);
+
+        if(data.ext_config){
+            try {
+                var ext = JSON.parse(data.ext_config);
+                if(data.type == 'qq'){
+                    $('#unionid_switch').prop('checked', !!ext.unionid);
+                }
+                if(data.type == 'cccyun'){
+                    $('input[name="cccyun_url"]').val(ext.cccyun_url || '');
+                    $('select[name="cccyun_type"]').val(ext.cccyun_type || 'qq');
+                }
+            } catch(e) {}
+        }
+        onTypeChange();
+        $('#modal-edit').modal('show');
+    }).fail(function(){
+        layer.close(ii);
+        showOAuthAdminRequestFailed();
+    });
+}
+
+// 兼容原按钮调用
+function showEdit(id){
+    if(id){
+        openEditProvider(id);
+    }else{
+        openAddProvider();
+    }
+}
+
+function deleteProvider(id, name){
+    layer.confirm('确定要删除 <b>'+escapeHtml(name)+'</b> 吗？<br/>删除后已绑定该提供商的用户将无法使用此账号登录。', {btn: ['确定删除','取消']}, function(){
+        var ii = layer.load(2, {shade:[0.1,'#fff']});
+        $.post('/system/oauth/op', {act:'del', id:id}, function(res){
+            layer.close(ii);
+            if(res.code == 0){
+                layer.msg(res.msg, {icon: 1, time: 1000}, function(){loadProviders();});
+            }else{
+                layer.alert(res.msg, {icon: 2});
+            }
+        }).fail(function(){
+            layer.close(ii);
+            showOAuthAdminRequestFailed();
+        });
+    });
+}
+
+function onTypeChange(){
+    var type = $('select[name="type"]').val();
+    $('.scopes-field').toggle(type !== 'qq' && type !== 'cccyun');
+    if(type === 'qq' || type === 'cccyun') $('input[name="scopes"]').val('');
+    $('.oauth2-fields').toggle(type === 'oauth2');
+    $('.oidc-fields').toggle(type === 'oidc');
+    $('.qq-fields').toggle(type === 'qq');
+    $('.cccyun-fields').toggle(type === 'cccyun');
+}
+
+function buildProviderExtConfig(){
+    var type = $('select[name="type"]').val();
+    if(type === 'qq' && $('#unionid_switch').is(':checked')){
+        return {unionid:true};
+    }
+    if(type === 'cccyun'){
+        var config = {cccyun_type: $('select[name="cccyun_type"]').val() || 'qq'};
+        var cccyunUrl = $.trim($('input[name="cccyun_url"]').val());
+        if(cccyunUrl !== ''){
+            config.cccyun_url = cccyunUrl;
+        }
+        return config;
+    }
+    return {};
+}
+
+function collectProviderForm(){
+    return {
+        act: oauthEditorMode,
+        id: oauthEditorMode === 'edit' ? oauthEditorId : '',
+        type: $('select[name="type"]').val(),
+        name: $('input[name="name"]').val(),
+        logo: $('input[name="logo"]').val(),
+        client_id: $('input[name="client_id"]').val(),
+        client_secret: $('input[name="client_secret"]').val(),
+        scopes: $('input[name="scopes"]').val(),
+        oauth_authorize_url: $('input[name="oauth_authorize_url"]').val(),
+        oauth_token_url: $('input[name="oauth_token_url"]').val(),
+        oauth_userinfo_url: $('input[name="oauth_userinfo_url"]').val(),
+        oidc_issuer: $('input[name="oidc_issuer"]').val(),
+        userinfo_fields: $('input[name="userinfo_fields"]').val(),
+        ext_config: JSON.stringify(buildProviderExtConfig()),
+        sort: $('input[name="sort"]').val(),
+        enabled: $('#enabled_checkbox').is(':checked') ? '1' : '0'
+    };
+}
+
+function validateJsonObject(value, label, requireStringValues){
+    if(!value) return true;
+    var obj;
+    try {
+        obj = JSON.parse(value);
+    } catch(e) {
+        layer.alert(label + '必须是有效 JSON', {icon:2});
+        return false;
+    }
+    if(!obj || typeof obj !== 'object' || Array.isArray(obj)){
+        layer.alert(label + '必须是有效 JSON 对象', {icon:2});
+        return false;
+    }
+    if(requireStringValues){
+        for(var key in obj){
+            if(typeof obj[key] !== 'string' || obj[key].trim() === ''){
+                layer.alert(label + '字段路径必须是非空字符串', {icon:2});
+                return false;
+            }
+            var candidates = obj[key].split(',');
+            for(var i=0; i<candidates.length; i++){
+                if(candidates[i].trim() === ''){
+                    layer.alert(label + '字段路径候选项不能为空', {icon:2});
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+function saveProvider(){
+    var params = collectProviderForm();
+    if(!validateJsonObject(params.userinfo_fields, '字段映射', true)) return false;
+    if(!validateJsonObject(params.ext_config, '扩展配置', false)) return false;
+    if(params.type === 'cccyun'){
+        var cccyunUrl = $.trim($('input[name="cccyun_url"]').val());
+        if(cccyunUrl !== '' && !/^https:\/\/[^\s/?#]+\/?$/i.test(cccyunUrl)){
+            layer.alert('彩虹聚合登录接口域名请填写 https:// 开头的基础域名，例如 https://u.cccyun.cc/', {icon:2});
+            return false;
+        }
+        var cccyunType = $('select[name="cccyun_type"]').val();
+        var allowed = ['qq','wx','alipay','sina','baidu','huawei','xiaomi','douyin','bilibili','dingtalk'];
+        if(allowed.indexOf(cccyunType) === -1){
+            layer.alert('请选择有效的彩虹聚合登录方式', {icon:2});
+            return false;
+        }
+    }
+    var ii = layer.load(2, {shade:[0.1,'#fff']});
+    $.post('/system/oauth/op', params, function(res){
+        layer.close(ii);
+        if(res.code == 0){
+            layer.msg(res.msg, {icon: 1, time: 1000}, function(){
+                $('#modal-edit').modal('hide');
+                loadProviders();
+            });
+        }else{
+            layer.alert(res.msg, {icon: 2});
+        }
+    }).fail(function(){
+        layer.close(ii);
+        showOAuthAdminRequestFailed();
+    });
+    return false;
+}
+
+$(document).ready(function(){
+    loadProviders();
+});
 </script>
 {/block}

--- a/config/app.php
+++ b/config/app.php
@@ -22,16 +22,13 @@ return [
     // 禁止URL访问的应用列表（自动多应用模式有效）
     'deny_app_list'    => [],
 
-    // 异常页面的模板文件
-    'exception_tmpl'   => app()->getThinkPath() . 'tpl/think_exception.tpl',
-
     // 错误显示信息,非调试模式有效
     'error_message'    => '页面错误！请稍后再试～',
     // 显示错误信息
-    'show_error_msg'   => true,
+    'show_error_msg'   => false,
     'exception_tmpl'   => \think\facade\App::getAppPath() . 'view/exception.tpl',
 
     'version' => '1050',
 
-    'dbversion' => '1049'
+    'dbversion' => '1050'
 ];

--- a/route/app.php
+++ b/route/app.php
@@ -31,12 +31,19 @@ Route::any('/dmtask/status', 'dmonitor/status');
 Route::any('/optimizeip/status', 'optimizeip/status');
 Route::get('/cron', 'system/cron');
 
+Route::get('/oauth/login/:id', 'OauthController/login')->middleware(SessionInit::class)->middleware(ViewOutput::class);
+Route::get('/oauth/callback/:id', 'OauthController/callback')->middleware(SessionInit::class)->middleware(ViewOutput::class);
+
 Route::group(function () {
     Route::any('/', 'index/index');
     Route::post('/changeskin', 'index/changeskin');
     Route::get('/cleancache', 'index/cleancache');
     Route::any('/setpwd', 'index/setpwd');
     Route::any('/totp/:action', 'index/totp');
+    Route::get('/user/center', 'index/userCenter');
+
+    Route::post('/oauth/bind/:id', 'OauthController/bind')->middleware(SessionInit::class);
+    Route::post('/oauth/unbind', 'OauthController/unbind');
     Route::get('/test', 'index/test');
 
     Route::post('/user/data', 'user/user_data');
@@ -171,6 +178,9 @@ Route::group(function () {
     Route::get('/system/customwebhooktest', 'system/customwebhooktest');
     Route::post('/system/proxytest', 'system/proxytest');
     Route::get('/system/cronset', 'system/cronset');
+
+    Route::post('/system/oauth/data', 'system/oauth_data');
+    Route::post('/system/oauth/op', 'system/oauth_op');
 
 })->middleware(CheckLogin::class)
 ->middleware(ViewOutput::class);


### PR DESCRIPTION
- 新增 QQ、GitHub、彩虹聚合登录、自定义 OAuth2、自定义 OIDC 的第三方登录能力。
- 新增 OAuth 提供商后台配置、账号绑定/解绑、TOTP 联动登录与禁用密码登录保护。
- 新增 `oauth_provider`、`user_oauth` 表及 `oauth_disable_password` 配置项，并同步安装 SQL / 更新 SQL。
- 新增命令行恢复入口：`php think reset oauth_disable_password`，用于禁用密码登录后的应急恢复。
