### PR TITLE
feat: 网宿CDNPro支持直接部署指定证书

### DIFF
--- a/app/lib/DeployHelper.php
+++ b/app/lib/DeployHelper.php
@@ -2122,6 +2122,7 @@ ctrl+x 保存退出<br/>',
                     'options' => [
                         ['value'=>'cdn', 'label'=>'CDN'],
                         ['value'=>'cdnpro', 'label'=>'CDN Pro'],
+                        ['value'=>'cdnpro_certificate', 'label'=>'CDN Pro证书管理'],
                         ['value'=>'certificate', 'label'=>'证书管理']
                     ],
                     'value' => 'cdn',
@@ -2144,7 +2145,7 @@ ctrl+x 保存退出<br/>',
                 'cert_id' => [
                     'name' => '证书ID',
                     'type' => 'input',
-                    'show' => 'product==\'certificate\'',
+                    'show' => 'product==\'certificate\'||product==\'cdnpro_certificate\'',
                     'placeholder' => '',
                     'required' => true,
                 ],

--- a/app/lib/deploy/wangsu.php
+++ b/app/lib/deploy/wangsu.php
@@ -44,6 +44,10 @@ class wangsu implements DeployInterface
             $cert_name = str_replace('*.', '', $certInfo['subject']['CN']) . '-' . $certInfo['validFrom_time_t'];
             $serial_no = strtolower($certInfo['serialNumberHex']);
             $this->get_cert_id($fullchain, $privatekey, $cert_name, $config['cert_id'], $serial_no, true);
+
+        } elseif ($config['product'] == 'cdnpro_certificate') {
+            $this->deploy_cdnpro_certificate($fullchain, $privatekey, $config, $info);
+
         } else {
             throw new Exception('未知的产品类型');
         }
@@ -213,6 +217,56 @@ class wangsu implements DeployInterface
         $info['cert_id'] = $cert_id;
     }
 
+    public function deploy_cdnpro_certificate($fullchain, $privatekey, $config, &$info)
+    {
+        $certInfo = openssl_x509_parse($fullchain, true);
+        if (!$certInfo) {
+            throw new Exception('证书解析失败');
+        }
+
+        $cert_name = str_replace('*.', '', $certInfo['subject']['CN']) . '-' . $certInfo['validFrom_time_t'];
+        $cert_id = isset($config['cert_id']) ? $config['cert_id'] : null;
+        if (empty($cert_id)) {
+            throw new Exception('证书ID不能为空');
+        }
+
+        $result = $this->update_cert_id_cdnpro($fullchain, $privatekey, $cert_name, $cert_id);
+        $cert_id = $result['cert_id'];
+
+        if (empty($result['updated'])) {
+            $info['cert_id'] = $cert_id;
+            return;
+        }
+
+        $certVersion = $result['version'];
+
+        // 下发证书部署任务
+        $deploymentTasks = [
+            'target' => 'production',
+            'actions' => [
+                [
+                    'action' => 'deploy_cert',
+                    'certificateId' => $cert_id,
+                    'version' => intval($certVersion),
+                ]
+            ],
+            'name' => 'Deploy certificate ' . $cert_name,
+        ];
+
+        try {
+            $data = $this->request('/cdn/deploymentTasks', $deploymentTasks, true, null, 'POST', false, ['Check-Certificate' => 'no', 'Check-Usage' => 'no']);
+        } catch (Exception $e) {
+            throw new Exception('下发证书部署任务失败：' . $e->getMessage());
+        }
+
+        $url_parts = parse_url($data);
+        $path_parts = explode('/', $url_parts['path']);
+        $deploymentTaskId = end($path_parts);
+
+        $this->log('证书部署任务下发成功，部署任务ID：' . $deploymentTaskId);
+        $info['cert_id'] = $cert_id;
+    }
+
     private function get_cert_id($fullchain, $privatekey, $cert_name, $cert_id = null, $serial_no = null, $overwrite = false)
     {
         if ($cert_id) {
@@ -347,6 +401,49 @@ class wangsu implements DeployInterface
         usleep(500000);
 
         return $cert_id;
+    }
+
+    private function update_cert_id_cdnpro($fullchain, $privatekey, $cert_name, $cert_id)
+    {
+        try {
+            $data = $this->request('/cdn/certificates/' . $cert_id);
+        } catch (Exception $e) {
+            throw new Exception('证书ID ' . $cert_id . ' 不存在或获取失败：' . $e->getMessage());
+        }
+
+        if (isset($data['name']) && $data['name'] == $cert_name) {
+            $this->log('证书已是最新，无需更新，证书ID：' . $cert_id);
+            return ['cert_id' => $cert_id, 'updated' => false];
+        }
+
+        $this->log('证书已过期，准备更新...');
+
+        $date = gmdate("D, d M Y H:i:s T");
+        $encryptedKey = $this->encryptPrivateKey($privatekey, $date);
+        $param = [
+            'name' => $cert_name,
+            'newVersion' => [
+                'privateKey' => $encryptedKey,
+                'certificate' => $fullchain,
+                'comments' => $cert_name,
+            ]
+        ];
+
+        try {
+            $location = $this->request('/cdn/certificates/' . $cert_id, $param, true, $date, 'PATCH', true);
+        } catch (Exception $e) {
+            throw new Exception('更新证书失败：' . $e->getMessage());
+        }
+
+        // 从 Location 头解析版本号，格式：.../certificates/{id}/versions/{version}
+        $version = 1;
+        if (is_string($location)) {
+            $path_parts = explode('/', parse_url($location, PHP_URL_PATH));
+            $version = intval(end($path_parts));
+        }
+
+        $this->log('更新证书成功，证书ID：' . $cert_id . '，版本号：' . $version);
+        return ['cert_id' => $cert_id, 'version' => $version, 'updated' => true];
     }
 
     private function encryptPrivateKey($privateKey, $date = null)


### PR DESCRIPTION
当前CDNPro域名证书部署流程采用每次上传新的证书然后在加速项目管理替换为新的证书文件实现。这种方法有个弊端是每次只能部署一个域名，而且会在CDNPro控制台遗留大量旧证书，并且如果子域名数量较多时需要大量部署子域名，效率较差。

本PR提供一个新方案，可以让用户指定一个已经上传的证书的ID作为部署目标，更新证书后只对目标证书发起新的版本部署，这样关联该证书的域名就能完成更新，不需要替换证书，也不会产生大量的旧证书。

<img width="1070" height="462" alt="image" src="https://github.com/user-attachments/assets/b2c2eefd-a4be-43a7-b14b-d5daa7350246" />
<img width="773" height="399" alt="image" src="https://github.com/user-attachments/assets/9f4fce8f-43ac-4b87-9ac7-c2699d5f6181" />
<img width="720" height="236" alt="image" src="https://github.com/user-attachments/assets/133653e3-14f5-4153-84ac-f472d217bb44" />
