### PR TITLE
fix: 移除废弃的 curl_close() 调用，兼容 PHP 8.5

### DIFF
--- a/app/lib/acme/ACMEv2.php
+++ b/app/lib/acme/ACMEv2.php
@@ -29,7 +29,6 @@ class ACMEv2
 	public function __destruct()
 	{
 		if (PHP_MAJOR_VERSION < 8 && $this->account_key) openssl_pkey_free($this->account_key);
-		if ($this->ch) curl_close($this->ch);
 	}
 
 	public function loadAccountKey($account_key_pem)
@@ -377,7 +376,7 @@ class ACMEv2
 		if (!empty($headers['content-type'])) {
 			switch ($headers['content-type']) {
 				case 'application/json':
-					if ($code[0] == '2') { // on non 2xx response: fall through to problem+json case
+					if (!is_null($code) && $code[0] == '2') { // on non 2xx response: fall through to problem+json case
 						$body = $this->json_decode($body);
 						if (isset($body['error']) && !(isset($body['status']) && $body['status'] === 'valid')) {
 							$this->handleError($body['error']);
@@ -391,7 +390,7 @@ class ACMEv2
 			}
 		}
 
-		if ($code[0] != '2') {
+		if (!is_null($code) && $code[0] != '2') {
 			throw new Exception('Invalid HTTP-Status-Code received: ' . $code . ': ' . print_r($body, true));
 		}
 

--- a/app/lib/client/AWS.php
+++ b/app/lib/client/AWS.php
@@ -286,7 +286,6 @@ class AWS
         $errno = curl_errno($ch);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -297,7 +296,6 @@ class AWS
             $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
             $response = substr($response, $headerSize);
         }
-        curl_close($ch);
 
         if ($httpCode >= 200 && $httpCode < 300) {
             if (empty($response)) return true;

--- a/app/lib/client/Aliyun.php
+++ b/app/lib/client/Aliyun.php
@@ -63,10 +63,8 @@ class Aliyun
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
-        curl_close($ch);
 
         $arr = json_decode($response, true);
         if ($httpCode == 200) {

--- a/app/lib/client/AliyunNew.php
+++ b/app/lib/client/AliyunNew.php
@@ -169,11 +169,9 @@ class AliyunNew
         $errno = curl_errno($ch);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
 
         $arr = json_decode($response, true);
         if ($httpCode == 200) {

--- a/app/lib/client/AliyunOSS.php
+++ b/app/lib/client/AliyunOSS.php
@@ -120,10 +120,8 @@ class AliyunOSS
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
-        curl_close($ch);
 
         if ($httpCode >= 200 && $httpCode < 300) {
             if (empty($response)) return true;

--- a/app/lib/client/BaiduCloud.php
+++ b/app/lib/client/BaiduCloud.php
@@ -159,10 +159,8 @@ class BaiduCloud
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
-        curl_close($ch);
 
         if (empty($response) && $httpCode == 200) {
             return true;

--- a/app/lib/client/Ctyun.php
+++ b/app/lib/client/Ctyun.php
@@ -150,10 +150,8 @@ class Ctyun
         $errno = curl_errno($ch);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
-        curl_close($ch);
 
         $arr = json_decode($response, true);
         if (isset($arr['statusCode']) && ($arr['statusCode'] == 100000 || $arr['statusCode'] == 0 && $this->endpoint == 'cf-global.ctapi.ctyun.cn')) {

--- a/app/lib/client/HuaweiCloud.php
+++ b/app/lib/client/HuaweiCloud.php
@@ -164,11 +164,9 @@ class HuaweiCloud
         $errno = curl_errno($ch);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
 
         $arr = json_decode($response, true);
         if ($arr) {

--- a/app/lib/client/HuaweiOBS.php
+++ b/app/lib/client/HuaweiOBS.php
@@ -107,10 +107,8 @@ class HuaweiOBS
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
-        curl_close($ch);
 
         if ($httpCode >= 200 && $httpCode < 300) {
             if (empty($response)) return true;

--- a/app/lib/client/Jdcloud.php
+++ b/app/lib/client/Jdcloud.php
@@ -168,11 +168,9 @@ class Jdcloud
         $errno = curl_errno($ch);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
 
         $arr = json_decode($response, true);
         if ($httpCode == 200) {

--- a/app/lib/client/Ksyun.php
+++ b/app/lib/client/Ksyun.php
@@ -189,11 +189,9 @@ class Ksyun
         $errno = curl_errno($ch);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
 
         $arr = json_decode($response, true);
         if ($httpCode == 200) {

--- a/app/lib/client/Qiniu.php
+++ b/app/lib/client/Qiniu.php
@@ -122,10 +122,8 @@ class Qiniu
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
-        curl_close($ch);
 
         if ($httpCode == 200) {
             $arr = json_decode($response, true);

--- a/app/lib/client/TencentCloud.php
+++ b/app/lib/client/TencentCloud.php
@@ -114,10 +114,8 @@ class TencentCloud
         $errno = curl_errno($ch);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
-        curl_close($ch);
 
         $arr = json_decode($response, true);
         if ($arr) {

--- a/app/lib/client/Volcengine.php
+++ b/app/lib/client/Volcengine.php
@@ -219,11 +219,9 @@ class Volcengine
         $errno = curl_errno($ch);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
 
         $arr = json_decode($response, true);
         if ($httpCode == 200) {

--- a/app/lib/deploy/k8s.php
+++ b/app/lib/deploy/k8s.php
@@ -175,7 +175,6 @@ class k8s implements DeployInterface
         $resp = curl_exec($ch);
         $code = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
         $err  = curl_error($ch);
-        curl_close($ch);
         return [$code, $resp, $err];
     }
 

--- a/app/lib/deploy/s3storage.php
+++ b/app/lib/deploy/s3storage.php
@@ -105,11 +105,9 @@ class s3storage implements DeployInterface
         $errno = curl_errno($ch);
         if ($errno) {
             $errmsg = curl_error($ch);
-            curl_close($ch);
             throw new Exception('Curl error: ' . $errmsg);
         }
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
 
         if ($httpCode >= 200 && $httpCode < 300) {
             return $response;

--- a/app/lib/mail/Sendcloud.php
+++ b/app/lib/mail/Sendcloud.php
@@ -31,7 +31,6 @@ class Sendcloud
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
         $json = curl_exec($ch);
-        curl_close($ch);
         $arr = json_decode($json, true);
         if ($arr['statusCode'] == 200) {
             return true;

--- a/app/utils/MsgNotice.php
+++ b/app/utils/MsgNotice.php
@@ -468,7 +468,6 @@ class MsgNotice
         curl_setopt($ch, CURLOPT_ENCODING, "gzip");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         $ret = curl_exec($ch);
-        curl_close($ch);
         return $ret;
     }
 }

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,9 +1,11 @@
 <IfModule mod_rewrite.c>
   Options +FollowSymlinks -Multiviews
   RewriteEngine On
+  RewriteBase /
 
   RewriteCond %{REQUEST_FILENAME} !-d
   RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteRule ^(.*)$ index.php/$1 [QSA,PT,L]
+  RewriteRule ^(.*)$ index.php [L,QSA,E=PATH_INFO:/$1]
+
   SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 </IfModule>


### PR DESCRIPTION
- 删除 18 个文件中共 32 处 curl_close() 调用（PHP 8.0+ 已为无操作）

- 修复 ACMEv2.php 中 $code 可能为 null 的潜在问题

- 调整 public/.htaccess 伪静态规则，兼容 Windows + CGI 模式